### PR TITLE
1-click+gas-step 0: Setup feature flags

### DIFF
--- a/src/modules/remote-config/plugins/firebase.ts
+++ b/src/modules/remote-config/plugins/firebase.ts
@@ -8,6 +8,7 @@ import type { RemoteConfig } from '../types';
 const defaultConfig: RemoteConfig = {
   extension_wallet_name_flags: {},
   extension_uninstall_link: '',
+  one_click_transactions_and_gas_abstraction: false,
   extension_loyalty_enabled: true,
   extension_asset_page_enabled: false,
   loyalty_config: {},
@@ -18,6 +19,7 @@ const defaultConfig: RemoteConfig = {
 const knownKeys: (keyof RemoteConfig)[] = [
   'extension_wallet_name_flags',
   'extension_uninstall_link',
+  'one_click_transactions_and_gas_abstraction',
   'extension_loyalty_enabled',
   'extension_asset_page_enabled',
   'loyalty_config',

--- a/src/modules/remote-config/plugins/firebase.ts
+++ b/src/modules/remote-config/plugins/firebase.ts
@@ -8,7 +8,7 @@ import type { RemoteConfig } from '../types';
 const defaultConfig: RemoteConfig = {
   extension_wallet_name_flags: {},
   extension_uninstall_link: '',
-  one_click_transactions_and_gas_abstraction: false,
+  one_click_transactions_and_gas_abstraction: true,
   extension_loyalty_enabled: true,
   extension_asset_page_enabled: false,
   loyalty_config: {},

--- a/src/modules/remote-config/types.ts
+++ b/src/modules/remote-config/types.ts
@@ -3,6 +3,7 @@ import type { WalletNameFlag } from 'src/shared/types/WalletNameFlag';
 export interface RemoteConfig {
   extension_wallet_name_flags: Record<string, WalletNameFlag[]>;
   extension_uninstall_link: string;
+  one_click_transactions_and_gas_abstraction: boolean;
   extension_loyalty_enabled: boolean;
   extension_asset_page_enabled: boolean;
   fee_comparison_config: Array<{

--- a/src/shared/core/useIsOneClickTransactionsAndGasAbstractionEnabled.ts
+++ b/src/shared/core/useIsOneClickTransactionsAndGasAbstractionEnabled.ts
@@ -1,0 +1,19 @@
+import { useRemoteConfigValue } from 'src/modules/remote-config/useRemoteConfigValue';
+import { useMemo } from 'react';
+import _ from 'lodash';
+
+export function useIsOneClickTransactionsAndGasAbstractionEnabled() {
+  const { data: oneClickTransactionsAndGasAbstraction } = useRemoteConfigValue(
+    'one_click_transactions_and_gas_abstraction'
+  );
+
+  return useMemo(() => {
+    // TODO: make oneClickTransactionsAndGasAbstraction default to false when it has been
+    // properly setup with the remote system
+    return (
+      (!_.isUndefined(oneClickTransactionsAndGasAbstraction) &&
+        oneClickTransactionsAndGasAbstraction) ||
+      true
+    );
+  }, [oneClickTransactionsAndGasAbstraction]);
+}

--- a/src/shared/core/useIsOneClickTransactionsAndGasAbstractionEnabled.ts
+++ b/src/shared/core/useIsOneClickTransactionsAndGasAbstractionEnabled.ts
@@ -5,5 +5,6 @@ export function useIsOneClickTransactionsAndGasAbstractionEnabled() {
     'one_click_transactions_and_gas_abstraction'
   );
 
-  return oneClickTransactionsAndGasAbstraction;
+  // TODO: remove this once we have a proper remote config
+  return oneClickTransactionsAndGasAbstraction || true;
 }

--- a/src/shared/core/useIsOneClickTransactionsAndGasAbstractionEnabled.ts
+++ b/src/shared/core/useIsOneClickTransactionsAndGasAbstractionEnabled.ts
@@ -1,19 +1,9 @@
 import { useRemoteConfigValue } from 'src/modules/remote-config/useRemoteConfigValue';
-import { useMemo } from 'react';
-import _ from 'lodash';
 
 export function useIsOneClickTransactionsAndGasAbstractionEnabled() {
   const { data: oneClickTransactionsAndGasAbstraction } = useRemoteConfigValue(
     'one_click_transactions_and_gas_abstraction'
   );
 
-  return useMemo(() => {
-    // TODO: make oneClickTransactionsAndGasAbstraction default to false when it has been
-    // properly setup with the remote system
-    return (
-      (!_.isUndefined(oneClickTransactionsAndGasAbstraction) &&
-        oneClickTransactionsAndGasAbstraction) ||
-      true
-    );
-  }, [oneClickTransactionsAndGasAbstraction]);
+  return oneClickTransactionsAndGasAbstraction;
 }


### PR DESCRIPTION
This PR is part of the steps to add Orby and support 1-click transactions and gas abstraction on the Zerion Chrome Extension. The same steps and similar code can be used on other Chrome Extension wallets.


[👉]  Step 0: Setup feature flags
- create a remotely configurable feature flag called `one_click_transactions_and_gas_abstraction`
- we will use this feature flag to gate access to the one click transactions and gas abstraction as we do progressive rollout of the feature.
- Zerion uses firebase but you can feature flag system of your choice such as launch darkly