### PR TITLE
1-click+gas-step 4: configure Orby to handle communication with app frontends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist
 /e2e-report/
 /blob-report/
 /playwright/.cache/
+src/content-script/core-webpage-injector.js
+src/content-script/core-webpage.js
+src/content-script/webpage.js

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ dist
 src/content-script/core-webpage-injector.js
 src/content-script/core-webpage.js
 src/content-script/webpage.js
+src/core-webpage-injector.js
+src/core-webpage.js
+src/webpage.js
+.ruby-version

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "A web3 wallet extension",
   "scripts": {
     "prestart": "node scripts/verifyDotEnv.cjs",
-    "start": "npm-run-all --parallel start:app type-check:watch",
+    "start": "npm run copy-webpage && npm-run-all --parallel start:app type-check:watch",
     "start:app": "parcel watch src/manifest.json src/ui/hardware-wallet/ledger.html --no-hmr --no-content-hash --no-autoinstall",
     "build": "echo \"Please run 'npm run build:production' instead\" && exit 1",
-    "build:production": "node scripts/build.js",
+    "build:production": "npm run copy-webpage && node scripts/build.js",
     "type-check": "tsc --noEmit",
     "type-check:watch": "tsc --noEmit --pretty --watch",
     "test:unit": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
@@ -18,7 +18,8 @@
     "lint": "eslint . --cache --fix --ext .ts,.tsx,.js",
     "format": "prettier --loglevel warn --write \"**/*.{ts,tsx,css,md}\"",
     "prepare": "husky install",
-    "postversion": "node ./scripts/manifest-version.js"
+    "postversion": "node ./scripts/manifest-version.js",
+    "copy-webpage": "cp ./node_modules/@orb-labs/orby-core-mini/dist/esm/webpage.min.js ./src/content-script/webpage.js && cp ./node_modules/@orb-labs/orby-core-mini/dist/esm/core_webpage.min.js ./src/content-script/core-webpage.js && cp ./node_modules/@orb-labs/orby-core-mini/dist/esm/core_webpage_injector.min.js ./src/content-script/core-webpage-injector.js"
   },
   "alias": {
     "src": "./src",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format": "prettier --loglevel warn --write \"**/*.{ts,tsx,css,md}\"",
     "prepare": "husky install",
     "postversion": "node ./scripts/manifest-version.js",
-    "copy-webpage": "cp ./node_modules/@orb-labs/orby-core-mini/dist/esm/webpage.min.js ./src/content-script/webpage.js && cp ./node_modules/@orb-labs/orby-core-mini/dist/esm/core_webpage.min.js ./src/content-script/core-webpage.js && cp ./node_modules/@orb-labs/orby-core-mini/dist/esm/core_webpage_injector.min.js ./src/content-script/core-webpage-injector.js"
+    "copy-webpage": "cp ./node_modules/@orb-labs/orby-core-mini/dist/esm/webpage.min.js ./src/webpage.js && cp ./node_modules/@orb-labs/orby-core-mini/dist/esm/core_webpage.min.js ./src/core-webpage.js && cp ./node_modules/@orb-labs/orby-core-mini/dist/esm/webpage.min.js ./src/content-script/webpage.js && cp ./node_modules/@orb-labs/orby-core-mini/dist/esm/core_webpage.min.js ./src/content-script/core-webpage.js && cp ./node_modules/@orb-labs/orby-core-mini/dist/esm/core_webpage_injector.min.js ./src/content-script/core-webpage-injector.js"
   },
   "alias": {
     "src": "./src",

--- a/src/background/Wallet/Wallet.ts
+++ b/src/background/Wallet/Wallet.ts
@@ -1687,6 +1687,50 @@ export class Wallet {
     return { ethereumChainConfigs, visitedChains };
   }
 
+  async addVirtualNodes({
+    params: { virtualNodeUrls },
+  }: WalletMethodParams<{
+    virtualNodeUrls: { rpcUrl: string; chainId: number }[];
+  }>) {
+    const preferences = await this.getPreferences({
+      context: INTERNAL_SYMBOL_CONTEXT,
+    });
+    const networksStore = getNetworksStore(preferences);
+
+    if (virtualNodeUrls.length == 0) {
+      return;
+    }
+
+    const networks = networksStore.getState().networks?.getNetworks();
+    if (!networks || networks.length == 0) {
+      return;
+    }
+
+    const allConfigs = virtualNodeUrls
+      .map(({ chainId, rpcUrl }) => {
+        const network = networks?.find(
+          (network) =>
+            network?.specification?.eip155?.id?.toString() ==
+            chainId?.toString()
+        );
+
+        if (!network) {
+          return null;
+        }
+
+        const configs = {
+          ...network,
+          rpc_url_user: rpcUrl,
+          rpc_url_internal: rpcUrl,
+        };
+
+        return configs;
+      })
+      .filter((network) => network !== null) as NetworkConfig[];
+
+    await networksStore.pushConfigs(...allConfigs);
+  }
+
   async getPendingTransactions({ context }: PublicMethodParams) {
     this.verifyInternalOrigin(context);
     return this.record?.transactions || [];

--- a/src/background/messaging/port-message-handlers/createHTTPConnectionMessageHandler.ts
+++ b/src/background/messaging/port-message-handlers/createHTTPConnectionMessageHandler.ts
@@ -31,7 +31,7 @@ export function createHttpConnectionMessageHandler(
           .eth_chainId({ context, id: msg.id })
           .then((chainIdStr) => {
             const chainId = normalizeChainId(chainIdStr);
-            return wallet.getRpcUrlByChainId({ chainId, type: 'public' });
+            return wallet.getRpcUrlByChainId({ chainId, type: 'internal' });
           })
           .then((url) => {
             invariant(url, `HttpConnection: No RpcUrl for ${context.origin}`);
@@ -52,7 +52,7 @@ export function createHttpConnectionMessageHandler(
         const chainId = normalizeChainId(requestContext.chainId);
         const wallet = getWallet();
         wallet
-          .getRpcUrlByChainId({ chainId, type: 'public' })
+          .getRpcUrlByChainId({ chainId, type: 'internal' })
           .then((url) => {
             invariant(url, `HttpConnection: No RpcUrl for ${context.origin}`);
             const httpConnection = new HttpConnection({ url });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -45,14 +45,21 @@
   "content_scripts": [
     {
       "all_frames": true,
-      "js": ["content-script/index.ts"],
+      "js": [
+        "content-script/core-webpage-injector.js",
+        "content-script/index.ts"
+      ],
       "matches": ["https://*/*", "http://localhost/*", "http://0.0.0.0/*"],
       "run_at": "document_start"
     }
   ],
   "web_accessible_resources": [
     {
-      "resources": ["content-script/in-page.ts"],
+      "resources": [
+        "content-script/in-page.ts",
+        "content-script/webpage.js",
+        "content-script/core-webpage.js"
+      ],
       "matches": ["<all_urls>"]
     }
   ],
@@ -62,7 +69,8 @@
     "scripting",
     "sidePanel",
     "storage",
-    "unlimitedStorage"
+    "unlimitedStorage",
+    "tabs"
   ],
   "host_permissions": ["http://*/*", "https://*/*"]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -57,8 +57,10 @@
     {
       "resources": [
         "content-script/in-page.ts",
+        "content-script/core-webpage.js",
         "content-script/webpage.js",
-        "content-script/core-webpage.js"
+        "webpage.js",
+        "core-webpage.js"
       ],
       "matches": ["<all_urls>"]
     }

--- a/src/ui/pages/ConnectedSites/ConnectedSite/ConnectedSite.tsx
+++ b/src/ui/pages/ConnectedSites/ConnectedSite/ConnectedSite.tsx
@@ -30,6 +30,7 @@ import { prepareForHref } from 'src/ui/shared/prepareForHref';
 import { UnstyledAnchor } from 'src/ui/ui-kit/UnstyledAnchor';
 import { useTransformTrigger } from 'src/ui/components/useTransformTrigger';
 import { Background } from 'src/ui/components/Background/Background';
+import { removeConnectedAppSession } from '@orb-labs/orby-core-mini';
 import { useRemovePermissionMutation } from '../shared/useRemovePermission';
 import { getConnectedSite } from '../shared/getConnectedSite';
 import { MetamaskMode } from './MetamaskMode';
@@ -55,6 +56,7 @@ function RevokeAllButton({
         onClick={() => {
           if (removeActionDialogRef.current) {
             showConfirmDialog(removeActionDialogRef.current).then(() => {
+              removeConnectedAppSession(origin);
               removePermissionMutation.mutate({ origin });
             });
           }
@@ -236,6 +238,9 @@ export function ConnectedSite() {
                                 showConfirmDialog(
                                   removeActionDialogRef.current
                                 ).then(() => {
+                                  removeConnectedAppSession(
+                                    connectedSite.origin
+                                  );
                                   removePermissionMutation.mutate({
                                     origin: connectedSite.origin,
                                     address: wallet.address,

--- a/src/ui/pages/ConnectedSites/ConnectedSites.tsx
+++ b/src/ui/pages/ConnectedSites/ConnectedSites.tsx
@@ -27,6 +27,7 @@ import { Spacer } from 'src/ui/ui-kit/Spacer';
 import { FillView } from 'src/ui/components/FillView';
 import type { InputHandle } from 'src/ui/ui-kit/Input/DebouncedInput';
 import { DebouncedInput } from 'src/ui/ui-kit/Input/DebouncedInput';
+import { removeConnectedAppSession } from '@orb-labs/orby-core-mini';
 import { ConnectedSite } from './ConnectedSite';
 
 function RevokeAllPermissionsComponent({
@@ -267,7 +268,13 @@ function ConnectedSitesMain() {
         <ConnectedSitesList
           showRevokeAll={!searchQuery}
           items={itemsToDisplay}
-          onRevokeAll={() => connectedSitesQuery.refetch()}
+          onRevokeAll={() => {
+            allConnectedSites?.map((site) => {
+              removeConnectedAppSession(site.origin);
+            });
+
+            connectedSitesQuery.refetch();
+          }}
         />
       ) : (
         <EmptyView


### PR DESCRIPTION
This PR is step 3 of the steps to add Orby and support 1-click transactions and gas abstraction on the Zerion Chrome Extension. The same steps and similar code can be used on other Chrome Extension wallets.


[✅] Step 0 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/4) : Setup feature flags
- create a remotely configurable feature flag called `one_click_transactions_and_gas_abstraction`
- we will use this feature flag to gate access to the one click transactions and gas abstraction as we do progressive rollout of the feature.
- Zerion uses firebase but you can feature flag system of your choice such as launch darkly

[✅]  Step 1 [(No PR needed)]: Get EVM and SVM testing accounts and set them up. 
- The accounts need to have some funds, though they do not need to be native funds but at least USDC on the chain you want to test on.
- Delete all approvals for EVM accounts using something like revoke cash (https://revoke.cash/)
- Add your accounts to the flag test / development group of the feature created above

[✅]  Step 2 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/5): Get the Orby API keys for an instance and add them to your environment variables.
- The team will give you keys and urls that look like:

        ORBY_PRIVATE_API_KEY=
        ORBY_PUBLIC_API_KEY=
        ORBY_BASE_URL=


- Note: the private and public keys correspond to a particular instance with specific features enabled on that instance. Given that we're working on 1-click transactions and gas abstraction, make sure that only those 2 features are be enabled.

[✅] Step 3 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/6): Add OrbyProvider to the root of your app
- add the @orb-labs/orby-react npm package
- move some components around so that we can add `OrbyProvider` easily
- initialize the OrbyProvider using the current wallet address
- `OrbyProvider`: Adding OrbyProvider to the root of the app setups all the context and variables that will be used in hooks and function calls to communicate with Orby. 
- Note: If you prefer not to use the Orby React package, you can also create your own functions and classes for calling Orby and setting/managing up context; we're also happy to walk you through the process / code if that's preferred.

[👉] Step 4: Configure Orby to handle communication with app frontends
- this is perhaps the most involved step of the integration. Generally, we want to inject scripts to into dapps that the user is connected to, and remove it when the user disconnect from the app. 
- Also, we need to use virtual node for all node requests (e.g. `eth_call`) that are routed to the apps from the wallet (some apps do this).
1. make sure the extension has the right permissions. Most extensions have them already so, you probably do not need to do anything but you need  `"activeTab"`, `"scripting"`, and `unlimitedStorage` permissions in the `src/manifest.json` file
2. add webpage.js and core-webpage.js to the manifest's web_accessible_resources
3. add core-webpage-injector.js to the manifest's content_scripts 
4. In your package.json add a command to copy the webpage.min.js to webpage.js, core_webpage.min.js to core-webpage.js and core_webpage_injector.min.js to core-webpage-injector.js. Put this files in the location where they can be build together with other content script files or you can copy them directly into the location of the content script files after build has completed. For Zerion extension, we add them to the `./src/content-script/` before building, and meaning the files are build together with the other content script files.
5. Call the `unifyBalancesOnApps` function your background script with the first argument being the location of the files from step 4 above relative to the root of the build output directory
7. Whenever the app starts get all active app sessions and then call the `useBulkConnectAppSessions` to register them to the background script. Similarly, call the `getVirtualNodeRpcUrlsForSupportedChains` function to get virtual nodes, and add them to your RPC state as the primary way to forward RPC requests from apps the orby. This is necessary because some apps still call wallets for balances, and even generic `eth_calls`.  For the Zerion Extension, this is done in the new `RegisterSessions` component, which is conditionally rendered if the feature flag is set.
9. Whenever a app is connected to the wallet, call the updateConnectedAppSession function
10. Whenever a app is disconnected to the wallet, call the removeConnectedAppSession function 

Testing: At this point, we want to test that the wallet is function as expected.
1. Testing gas abstraction:
- `Control:` Using the Zerion wallet on App store, connect to uniswap with an account that does not have native funds on a chain like BNB Chain, ETH Mainnet, Arbitrum, Base or Optimism.  You should be blocked with a "Insufficient funds for gas" error when you attempt a swap.
- `Orby Enabled:` Now, switch to this Orby enabled Zerion wallet but with the same account. You should not be blocked with a "Insufficient funds for gas" any error when you attempt a swap, and instead you should be able to send the transaction to the wallet for signing.
1. Testing 1-click transactions:
- `Control:` Using the Zerion wallet on App store, connect to uniswap with an account with sufficient funds on a chain like BNB Chain, ETH Mainnet, Arbitrum, Base or Optimism, and attempt a swap with an ERC20 token (e.g. USDC) that has not been approved on uniswap. You should see an "Approve and Swap" CTA when you attempt to swap. Clicking the button sends an ERC20 approval request to the wallet. 
- `Orby Enabled:` Now, switch to this Orby enabled Zerion wallet but with the same account. You should see "Swap" with no approvals needed. Clicking the CTA sends a permit2 typedData to the wallet and not an approval transaction.


