### PR TITLE
1-click+gas-step 5: using useGetOperationsToExecuteTransaction for app transactions

### DIFF
--- a/src/shared/core/useIsOrbyEnabled.ts
+++ b/src/shared/core/useIsOrbyEnabled.ts
@@ -1,0 +1,15 @@
+import { useIsOrbySupportedChain } from '@orb-labs/orby-react';
+import { useMemo } from 'react';
+import _ from 'lodash';
+import { useIsOneClickTransactionsAndGasAbstractionEnabled } from './useIsOneClickTransactionsAndGasAbstractionEnabled';
+
+export function useIsOrbyEnabled(chainId?: bigint | undefined) {
+  const oneClickTransactionsAndGasAbstractionEnabled =
+    useIsOneClickTransactionsAndGasAbstractionEnabled();
+
+  const { isSupported } = useIsOrbySupportedChain(chainId);
+
+  return useMemo(() => {
+    return oneClickTransactionsAndGasAbstractionEnabled && isSupported;
+  }, [oneClickTransactionsAndGasAbstractionEnabled, isSupported]);
+}

--- a/src/ui/components/TokenStateSection/TokenStateSection.tsx
+++ b/src/ui/components/TokenStateSection/TokenStateSection.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Surface } from 'src/ui/ui-kit/Surface';
+import { UIText } from 'src/ui/ui-kit/UIText';
+import { VStack } from 'src/ui/ui-kit/VStack';
+import { HStack } from 'src/ui/ui-kit/HStack';
+import type { State } from '@orb-labs/orby-core';
+import { TokenIcon } from 'src/ui/ui-kit/TokenIcon';
+import { Media } from 'src/ui/ui-kit/Media';
+import { formatTokenValue } from 'src/shared/units/formatTokenValue';
+import { AssetQuantity } from 'src/ui/components/AssetQuantity';
+import { BigNumber } from 'bignumber.js';
+
+export function TokenStateSection({
+  title,
+  tokens,
+}: {
+  title: string;
+  tokens: State | undefined;
+}) {
+  const fungibleTokens = tokens?.getFungibleTokens();
+  if (!fungibleTokens) {
+    return null;
+  }
+
+  if (fungibleTokens.length === 0) {
+    return (
+      <Surface>
+        <VStack gap={12} style={{ paddingBlock: 24, paddingLeft: 16 }}>
+          <UIText kind="small/regular" color="var(--neutral-500)">
+            {title}
+          </UIText>
+          <UIText kind="body/regular" color="white">
+            No tokens moving
+          </UIText>
+        </VStack>
+      </Surface>
+    );
+  }
+
+  return (
+    <Surface>
+      <VStack gap={12}>
+        <UIText kind="small/regular" color="var(--neutral-500)">
+          {title}
+        </UIText>
+        {fungibleTokens.map((tokenAmount, index) => {
+          // Convert raw amount to decimal based on token decimals
+          const rawAmount = BigNumber(tokenAmount.toRawAmount().toString());
+          const decimals = tokenAmount.token.currency().decimals;
+          const decimalAmount = rawAmount.dividedBy(
+            BigNumber(10).pow(decimals)
+          );
+
+          return (
+            <Media
+              key={`${tokenAmount.token.identifier()}-${index}`}
+              gap={12}
+              vGap={0}
+              image={
+                <TokenIcon
+                  size={36}
+                  src={tokenAmount.token.currency().logoUrl}
+                  symbol={tokenAmount.token.currency().symbol}
+                  title={tokenAmount.token.currency().name}
+                />
+              }
+              text={
+                <UIText kind="headline/h3">
+                  <HStack gap={4} alignItems="center">
+                    <AssetQuantity commonQuantity={decimalAmount} />
+                    <span>{tokenAmount.token.currency().symbol}</span>
+                  </HStack>
+                </UIText>
+              }
+              detailText={
+                <UIText kind="small/regular" color="var(--neutral-500)">
+                  {formatTokenValue(
+                    decimalAmount,
+                    tokenAmount.token.currency().symbol
+                  )}
+                </UIText>
+              }
+            />
+          );
+        })}
+      </VStack>
+    </Surface>
+  );
+}

--- a/src/ui/components/TokenStateSection/index.ts
+++ b/src/ui/components/TokenStateSection/index.ts
@@ -1,0 +1,1 @@
+export { TokenStateSection } from './TokenStateSection';

--- a/src/ui/pages/SendTransaction/SendTransaction.tsx
+++ b/src/ui/pages/SendTransaction/SendTransaction.tsx
@@ -99,10 +99,8 @@ import ScrollIcon from 'jsx:src/ui/assets/scroll.svg';
 import ArrowDownIcon from 'jsx:src/ui/assets/caret-down-filled.svg';
 import { SiteFaviconImg } from 'src/ui/components/SiteFaviconImg';
 import { NetworkId } from 'src/modules/networks/NetworkId';
-import { useGetOperationsToExecuteTransaction } from '@orb-labs/orby-react';
-import { CreateOperationsStatus } from '@orb-labs/orby-core';
-import _ from 'lodash';
 import { useIsOrbyEnabled } from 'src/shared/core/useIsOrbyEnabled';
+import { useOrbyGetOperationsToSignTransactionOrSignTypedData } from 'src/ui/shared/hooks/useOrbyGetOperationsToSignTransactionOrSignTypedData';
 import type { PopoverToastHandle } from '../Settings/PopoverToast';
 import { PopoverToast } from '../Settings/PopoverToast';
 import { TransactionConfiguration } from './TransactionConfiguration';
@@ -564,9 +562,6 @@ function SendTransactionContent({
     });
 
   const [allowanceQuantityBase, setAllowanceQuantityBase] = useState('');
-  const [operationSetError, setOperationSetError] = useState<string | null>(
-    null
-  );
 
   const configureTransactionToBeSigned = useEvent(
     async (
@@ -597,26 +592,6 @@ function SendTransactionContent({
     isDefault: true,
   });
 
-  const gasToken = useMemo(() => {
-    return selectedGasToken?.standardizedTokenId
-      ? { standardizedTokenId: selectedGasToken.standardizedTokenId }
-      : undefined;
-  }, [selectedGasToken]);
-
-  const { operationSet, isLoading: OperationSetLoading } =
-    useGetOperationsToExecuteTransaction(
-      isOrbyEnabled ? (wallet?.address as string) : undefined,
-      isOrbyEnabled && populatedTransaction?.chainId
-        ? BigInt(populatedTransaction?.chainId as number)
-        : undefined,
-      populatedTransaction?.to as string,
-      populatedTransaction?.data as string,
-      populatedTransaction?.value
-        ? BigInt(populatedTransaction?.value.toString())
-        : undefined,
-      gasToken
-    );
-
   const selectGasToken = useCallback(
     (gasToken?: GasTokenInput) => {
       if (gasToken) {
@@ -626,35 +601,13 @@ function SendTransactionContent({
     [setSelectedGasToken]
   );
 
-  // Check for operation set errors and update error state
-  React.useEffect(() => {
-    if (operationSet?.status && isOrbyEnabled) {
-      let errorMessage: string | null = null;
-
-      if (operationSet.status === CreateOperationsStatus.INSUFFICIENT_FUNDS) {
-        errorMessage = 'Insufficient funds';
-      } else if (
-        operationSet.status === CreateOperationsStatus.NO_EXECUTION_PATH
-      ) {
-        errorMessage = 'No execution path';
-      } else if (
-        operationSet.status ===
-        CreateOperationsStatus.INSUFFICIENT_FUNDS_FOR_GAS
-      ) {
-        errorMessage = 'Insufficient funds for gas. Choose another token';
-      } else if (operationSet.status === CreateOperationsStatus.INTERNAL) {
-        errorMessage = 'Internal error';
-      } else if (
-        operationSet.status === CreateOperationsStatus.INVALID_ARGUMENT
-      ) {
-        errorMessage = 'Invalid argument';
-      }
-
-      setOperationSetError(errorMessage);
-    } else {
-      setOperationSetError(null);
-    }
-  }, [operationSet?.status, isOrbyEnabled]);
+  const { operationSet, operationSetError, operationSetLoading } =
+    useOrbyGetOperationsToSignTransactionOrSignTypedData(
+      populatedTransaction,
+      wallet,
+      isOrbyEnabled,
+      selectedGasToken
+    );
 
   const paymasterPossible =
     USE_PAYMASTER_FEATURE && Boolean(network?.supports_sponsored_transactions);
@@ -948,11 +901,11 @@ function SendTransactionContent({
                   ref={sendTxBtnRef}
                   onClick={() => sendTransaction()}
                   isLoading={
-                    sendTransactionMutation.isLoading || OperationSetLoading
+                    sendTransactionMutation.isLoading || operationSetLoading
                   }
                   disabled={
                     sendTransactionMutation.isLoading ||
-                    OperationSetLoading ||
+                    operationSetLoading ||
                     !!operationSetError
                   }
                   buttonKind={

--- a/src/ui/pages/SendTransaction/TransactionAdvancedView/TransactionAdvancedView.tsx
+++ b/src/ui/pages/SendTransaction/TransactionAdvancedView/TransactionAdvancedView.tsx
@@ -28,6 +28,8 @@ import { DialogButtonValue } from 'src/ui/ui-kit/ModalDialogs/DialogTitle';
 import { Spacer } from 'src/ui/ui-kit/Spacer';
 import { PageBottom } from 'src/ui/components/PageBottom';
 import type { MultichainTransaction } from 'src/shared/types/MultichainTransaction';
+import type { OperationSet } from '@orb-labs/orby-core';
+import { TokenStateSection } from 'src/ui/components/TokenStateSection';
 
 function maybeHexValue(value?: BigNumberish | null): string | null {
   return value ? valueToHex(value) : null;
@@ -205,6 +207,7 @@ export function TransactionAdvancedView({
   interpretation,
   addressAction,
   onCopyData,
+  operationSet,
 }: {
   networks: Networks;
   chain: Chain;
@@ -212,6 +215,7 @@ export function TransactionAdvancedView({
   interpretation?: InterpretResponse | null;
   addressAction: AnyAddressAction;
   onCopyData?: () => void;
+  operationSet?: OperationSet;
 }) {
   const transactionFormatted = useMemo(() => {
     if (transaction.evm) {
@@ -240,6 +244,18 @@ export function TransactionAdvancedView({
           chain={chain}
           networks={networks}
         />
+        {operationSet && (
+          <>
+            <TokenStateSection
+              title="Input Tokens"
+              tokens={operationSet.inputState}
+            />
+            <TokenStateSection
+              title="Output Tokens"
+              tokens={operationSet.outputState}
+            />
+          </>
+        )}
         {transaction.evm ? (
           <TransactionDetails
             networks={networks}

--- a/src/ui/shared/hooks/useOperationSetError.ts
+++ b/src/ui/shared/hooks/useOperationSetError.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { CreateOperationsStatus } from '@orb-labs/orby-core';
+import type { OperationSet } from '@orb-labs/orby-core';
+
+/**
+ * Custom hook that monitors operation set status and returns appropriate error messages
+ * @param operationSet - The operation set to monitor
+ * @param isOrbyEnabled - Whether Orby is enabled for the current chain
+ * @returns The error message string or null if no error
+ */
+export function useOperationSetError(
+  operationSet: OperationSet | undefined,
+  isOrbyEnabled: boolean | undefined
+): string | null {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (operationSet?.status && isOrbyEnabled) {
+      let newErrorMessage: string | null = null;
+
+      if (operationSet.status === CreateOperationsStatus.INSUFFICIENT_FUNDS) {
+        newErrorMessage = 'Insufficient funds';
+      } else if (
+        operationSet.status === CreateOperationsStatus.NO_EXECUTION_PATH
+      ) {
+        newErrorMessage = 'No execution path';
+      } else if (
+        operationSet.status ===
+        CreateOperationsStatus.INSUFFICIENT_FUNDS_FOR_GAS
+      ) {
+        newErrorMessage = 'Insufficient funds for gas. Choose another token';
+      } else if (operationSet.status === CreateOperationsStatus.INTERNAL) {
+        newErrorMessage = 'Internal error';
+      } else if (
+        operationSet.status === CreateOperationsStatus.INVALID_ARGUMENT
+      ) {
+        newErrorMessage = 'Invalid argument';
+      }
+
+      setErrorMessage(newErrorMessage);
+    } else {
+      setErrorMessage(null);
+    }
+  }, [operationSet?.status, isOrbyEnabled]);
+
+  return errorMessage;
+}

--- a/src/ui/shared/hooks/useOrbyGetOperationsToSignTransactionOrSignTypedData.ts
+++ b/src/ui/shared/hooks/useOrbyGetOperationsToSignTransactionOrSignTypedData.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+import type { IncomingTransactionWithChainId } from 'src/modules/ethereum/types/IncomingTransaction';
+import { useGetOperationsToSignTransactionOrSignTypedData } from '@orb-labs/orby-react';
+import type { ExternallyOwnedAccount } from 'src/shared/types/ExternallyOwnedAccount';
+import type { GasTokenInput } from 'src/ui/pages/SendTransaction/NetworkFee/NetworkFee';
+import { useOperationSetError } from './useOperationSetError';
+
+export function useOrbyGetOperationsToSignTransactionOrSignTypedData(
+  populatedTransaction: IncomingTransactionWithChainId | undefined,
+  wallet: ExternallyOwnedAccount,
+  isOrbyEnabled: boolean | undefined,
+  selectedGasToken: GasTokenInput | undefined
+) {
+  const gasToken = useMemo(() => {
+    return selectedGasToken?.standardizedTokenId
+      ? { standardizedTokenId: selectedGasToken.standardizedTokenId }
+      : undefined;
+  }, [selectedGasToken]);
+
+  const { operationSet, isLoading: operationSetLoading } =
+    useGetOperationsToSignTransactionOrSignTypedData(
+      populatedTransaction?.data as string,
+      populatedTransaction?.to as string,
+      populatedTransaction?.value
+        ? BigInt(populatedTransaction?.value.toString())
+        : undefined,
+      isOrbyEnabled ? (wallet?.address as string) : undefined,
+      isOrbyEnabled && populatedTransaction?.chainId
+        ? BigInt(populatedTransaction?.chainId as number)
+        : undefined,
+      gasToken
+    );
+
+  const operationSetError = useOperationSetError(operationSet, isOrbyEnabled);
+
+  return { operationSet, operationSetError, operationSetLoading };
+}


### PR DESCRIPTION
This PR is step 3 of the steps to add Orby and support 1-click transactions and gas abstraction on the Zerion Chrome Extension. The same steps and similar code can be used on other Chrome Extension wallets.


[✅] Step 0 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/4) : Setup feature flags
- create a remotely configurable feature flag called `one_click_transactions_and_gas_abstraction`
- we will use this feature flag to gate access to the one click transactions and gas abstraction as we do progressive rollout of the feature.
- Zerion uses firebase but you can feature flag system of your choice such as launch darkly

[✅]  Step 1 [(No PR needed)]: Get EVM and SVM testing accounts and set them up. 
- The accounts need to have some funds, though they do not need to be native funds but at least USDC on the chain you want to test on.
- Delete all approvals for EVM accounts using something like revoke cash (https://revoke.cash/)
- Add your accounts to the flag test / development group of the feature created above

[✅]  Step 2 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/5): Get the Orby API keys for an instance and add them to your environment variables.
- The team will give you keys and urls that look like:

        ORBY_PRIVATE_API_KEY=
        ORBY_PUBLIC_API_KEY=
        ORBY_BASE_URL=


- Note: the private and public keys correspond to a particular instance with specific features enabled on that instance. Given that we're working on 1-click transactions and gas abstraction, make sure that only those 2 features are be enabled.

[✅] Step 3 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/6): Add OrbyProvider to the root of your app
- add the @orb-labs/orby-react npm package
- move some components around so that we can add `OrbyProvider` easily
- initialize the OrbyProvider using the current wallet address
- `OrbyProvider`: Adding OrbyProvider to the root of the app setups all the context and variables that will be used in hooks and function calls to communicate with Orby. 
- Note: If you prefer not to use the Orby React package, you can also create your own functions and classes for calling Orby and setting/managing up context; we're also happy to walk you through the process / code if that's preferred.

[✅] Step 4 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/7): Configure Orby to handle communication with app frontends
- this is perhaps the most involved step of the integration. Generally, we want to inject scripts to into dapps that the user is connected to, and remove it when the user disconnect from the app. 
- Also, we need to use virtual node for all node requests (e.g. `eth_call`) that are routed to the apps from the wallet (some apps do this).
1. make sure the extension has the right permissions. Most extensions have them already so, you probably do not need to do anything but you need  `"activeTab"`, `"scripting"`, and `unlimitedStorage` permissions in the `src/manifest.json` file
2. add webpage.js and core-webpage.js to the manifest's web_accessible_resources
3. add core-webpage-injector.js to the manifest's content_scripts 
4. In your package.json add a command to copy the webpage.min.js to webpage.js, core_webpage.min.js to core-webpage.js and core_webpage_injector.min.js to core-webpage-injector.js. Put this files in the location where they can be build together with other content script files or you can copy them directly into the location of the content script files after build has completed. For Zerion extension, we add them to the `./src/content-script/` before building, and meaning the files are build together with the other content script files.
5. Call the `unifyBalancesOnApps` function your background script with the first argument being the location of the files from step 4 above relative to the root of the build output directory
7. Whenever the app starts get all active app sessions and then call the `useBulkConnectAppSessions` to register them to the background script. Similarly, call the `getVirtualNodeRpcUrlsForSupportedChains` function to get virtual nodes, and add them to your RPC state as the primary way to forward RPC requests from apps the orby. This is necessary because some apps still call wallets for balances, and even generic `eth_calls`.  For the Zerion Extension, this is done in the new `RegisterSessions` component, which is conditionally rendered if the feature flag is set.
9. Whenever a app is connected to the wallet, call the updateConnectedAppSession function
10. Whenever a app is disconnected to the wallet, call the removeConnectedAppSession function 

Testing: At this point, we want to test that the wallet is function as expected.
1. Testing gas abstraction:
- `Control:` Using the Zerion wallet on App store, connect to uniswap with an account that does not have native funds on a chain like BNB Chain, ETH Mainnet, Arbitrum, Base or Optimism.  You should be blocked with a "Insufficient funds for gas" error when you attempt a swap.
- `Orby Enabled:` Now, switch to this Orby enabled Zerion wallet but with the same account. You should not be blocked with a "Insufficient funds for gas" any error when you attempt a swap, and instead you should be able to send the transaction to the wallet for signing.
1. Testing 1-click transactions:
- `Control:` Using the Zerion wallet on App store, connect to uniswap with an account with sufficient funds on a chain like BNB Chain, ETH Mainnet, Arbitrum, Base or Optimism, and attempt a swap with an ERC20 token (e.g. USDC) that has not been approved on uniswap. You should see an "Approve and Swap" CTA when you attempt to swap. Clicking the button sends an ERC20 approval request to the wallet. 
- `Orby Enabled:` Now, switch to this Orby enabled Zerion wallet but with the same account. You should see "Swap" with no approvals needed. Clicking the CTA sends a permit2 typedData to the wallet and not an approval transaction.


[👉] Step 5: Ping Orby to get  operations for every send transaction from apps
- We add a `useIsOrbyEnabled` hook to check if a chain is orby enabled and if a user has the feature flag enabled
- if orby is enabled, we call the `useGetOperationsToExecuteTransaction` with the transaction data from the user.
- Once we get the operations from Orby, we display them to the user under the details tab
- we also allow the user to pick custom gas tokens from the list of tokens that the user has

Testing: 
- connect to uniswap and initiate a transaction. 
- when the transaction is rendered by the wallet, there should be a way to pick a gas token based on the balances you have on that chain (as shown below)
<img width="357" height="147" alt="Screenshot 2025-07-15 at 01 54 22" src="https://github.com/user-attachments/assets/f00a9e11-9a4c-43ba-9aa4-000346017d15" />

- when you click the details tab, you should see the tokens going in and out of your account
<img width="355" height="237" alt="Screenshot 2025-07-15 at 01 54 56" src="https://github.com/user-attachments/assets/b4cabd5d-d7c6-4055-b047-1fd30dbb50ec" />


- when you click the gas dropdown, you should be able to choose the token of choice for paying for gas
<img width="358" height="480" alt="Screenshot 2025-07-15 at 01 56 33" src="https://github.com/user-attachments/assets/18af3299-cdba-47c0-8073-25fcd6f94aa1" />


- when a custom gas token is chosen, the native token does not show on the input tokens of the details page (e.g. the image below using DAI).
<img width="358" height="267" alt="Screenshot 2025-07-15 at 01 58 36" src="https://github.com/user-attachments/assets/e92a0bef-637c-4d8b-9d42-8c9eb4681575" />


- if you pick a token that is not enough to pay for gas or if there is not enough native tokens for gas, an error is shown
<img width="349" height="215" alt="Screenshot 2025-07-15 at 01 59 50" src="https://github.com/user-attachments/assets/e0aa144e-48fe-4984-84e3-268c30de3126" />
