### PR TITLE
1-click+gas-step 6: Ping Orby to get  operations for signTypedData call from apps

### DIFF
--- a/src/ui/pages/SendTransaction/SendTransaction.tsx
+++ b/src/ui/pages/SendTransaction/SendTransaction.tsx
@@ -585,7 +585,10 @@ function SendTransactionContent({
   const network = networks.getByNetworkId(chain) || null;
   const source = preferences?.testnetMode?.on ? 'testnet' : 'mainnet';
 
-  const isOrbyEnabled = useIsOrbyEnabled(BigInt(populatedTransaction?.chainId));
+  const chainId = populatedTransaction?.chainId
+    ? BigInt(populatedTransaction?.chainId)
+    : undefined;
+  const isOrbyEnabled = useIsOrbyEnabled(chainId);
   const [selectedGasToken, setSelectedGasToken] = useState<GasTokenInput>({
     name: 'Native Token',
     standardizedTokenId: undefined,
@@ -603,10 +606,11 @@ function SendTransactionContent({
 
   const { operationSet, operationSetError, operationSetLoading } =
     useOrbyGetOperationsToSignTransactionOrSignTypedData(
-      populatedTransaction,
+      { evm: populatedTransaction, typedData: undefined },
       wallet,
       isOrbyEnabled,
-      selectedGasToken
+      selectedGasToken,
+      chainId
     );
 
   const paymasterPossible =

--- a/src/ui/pages/SignTypedData/SignTypedData.tsx
+++ b/src/ui/pages/SignTypedData/SignTypedData.tsx
@@ -64,14 +64,8 @@ import {
   SecurityStatusBackground,
 } from 'src/ui/shared/security-check';
 import { INTERNAL_ORIGIN } from 'src/background/constants';
-import {
-  useGetFungibleTokenPortfolio,
-  useGetOperationsToSignTransactionOrSignTypedData,
-} from '@orb-labs/orby-react';
-import {
-  CreateOperationsStatus,
-  type OnchainOperation,
-} from '@orb-labs/orby-core';
+import { useGetFungibleTokenPortfolio } from '@orb-labs/orby-react';
+import { type OnchainOperation } from '@orb-labs/orby-core';
 import type { OperationSet, StandardizedBalance } from '@orb-labs/orby-core';
 import type { Client } from 'viem';
 import type { HttpTransport } from 'viem';
@@ -79,6 +73,7 @@ import type { PublicRpcSchema } from 'viem';
 import type { OrbyActions } from '@orb-labs/orby-viem-extension';
 import _ from 'lodash';
 import { useIsOrbyEnabled } from 'src/shared/core/useIsOrbyEnabled';
+import { useOrbyGetOperationsToSignTransactionOrSignTypedData } from 'src/ui/shared/hooks/useOrbyGetOperationsToSignTransactionOrSignTypedData';
 import { PopoverToast } from '../Settings/PopoverToast';
 import type { PopoverToastHandle } from '../Settings/PopoverToast';
 import { txErrorToMessage } from '../SendTransaction/shared/transactionErrorToMessage';
@@ -163,7 +158,8 @@ function TypedDataDefaultView({
   const dialogRef = useRef<HTMLDialogElementInterface | null>(null);
   const [params] = useSearchParams();
   const { preferences } = usePreferences();
-  const isOrbyEnabled = useIsOrbyEnabled(BigInt(chain.value));
+  const chainId = chain && networks ? networks.getChainId(chain) : null;
+  const isOrbyEnabled = useIsOrbyEnabled(chainId ? BigInt(chainId) : undefined);
 
   const addressAction = interpretation?.action;
   const recipientAddress = addressAction?.label?.display_value.wallet_address;
@@ -541,9 +537,6 @@ function SignTypedDataContent({
   const navigate = useNavigate();
 
   const [allowanceQuantityBase, setAllowanceQuantityBase] = useState('');
-  const [operationSetError, setOperationSetError] = useState<string | null>(
-    null
-  );
 
   const typedData = useMemo(() => {
     const result = toTypedData(typedDataRaw);
@@ -585,25 +578,21 @@ function SignTypedDataContent({
     isDefault: true,
   });
 
-  const gasToken = useMemo(() => {
-    return selectedGasToken?.standardizedTokenId
-      ? { standardizedTokenId: selectedGasToken.standardizedTokenId }
-      : undefined;
-  }, [selectedGasToken]);
   const {
-    operations,
     operationSet,
+    operationSetError,
+    operationSetLoading,
+    operations,
     virtualNode,
     aggregateFee,
-    isLoading: OperationSetLoading,
-  } = useGetOperationsToSignTransactionOrSignTypedData(
-    JSON.stringify(typedData),
-    undefined,
-    undefined,
-    isOrbyEnabled ? wallet.address : undefined,
-    chainId && isOrbyEnabled ? BigInt(chainId) : undefined,
-    gasToken
+  } = useOrbyGetOperationsToSignTransactionOrSignTypedData(
+    { evm: undefined, typedData: typedDataRaw },
+    wallet,
+    isOrbyEnabled,
+    selectedGasToken,
+    chainId ? BigInt(chainId) : undefined
   );
+
   const { fungibleTokens } = useGetFungibleTokenPortfolio(
     undefined,
     chainId && isOrbyEnabled ? BigInt(chainId) : undefined
@@ -617,35 +606,6 @@ function SignTypedDataContent({
     },
     [setSelectedGasToken]
   );
-
-  React.useEffect(() => {
-    if (operationSet?.status && isOrbyEnabled) {
-      let errorMessage: string | null = null;
-
-      if (operationSet.status === CreateOperationsStatus.INSUFFICIENT_FUNDS) {
-        errorMessage = 'Insufficient funds';
-      } else if (
-        operationSet.status === CreateOperationsStatus.NO_EXECUTION_PATH
-      ) {
-        errorMessage = 'No execution path';
-      } else if (
-        operationSet.status ===
-        CreateOperationsStatus.INSUFFICIENT_FUNDS_FOR_GAS
-      ) {
-        errorMessage = 'Insufficient funds for gas. Choose another token';
-      } else if (operationSet.status === CreateOperationsStatus.INTERNAL) {
-        errorMessage = 'Internal error';
-      } else if (
-        operationSet.status === CreateOperationsStatus.INVALID_ARGUMENT
-      ) {
-        errorMessage = 'Invalid argument';
-      }
-
-      setOperationSetError(errorMessage);
-    } else {
-      setOperationSetError(null);
-    }
-  }, [operationSet?.status, isOrbyEnabled]);
 
   const { data: interpretation, ...interpretQuery } = useQuery({
     queryKey: [
@@ -712,7 +672,7 @@ function SignTypedDataContent({
             operationSet={operationSet}
             operations={operations}
             virtualNode={virtualNode}
-            isLoadingOperationSet={OperationSetLoading}
+            isLoadingOperationSet={operationSetLoading}
             selectedGasToken={selectedGasToken}
             setSelectedGasToken={selectGasToken}
             operationSetError={operationSetError}

--- a/src/ui/pages/SignTypedData/TypedDataAdvancedView/TypedDataAdvancedView.tsx
+++ b/src/ui/pages/SignTypedData/TypedDataAdvancedView/TypedDataAdvancedView.tsx
@@ -4,13 +4,33 @@ import { Surface } from 'src/ui/ui-kit/Surface';
 import { VStack } from 'src/ui/ui-kit/VStack';
 import type { InterpretInput } from 'src/modules/ethereum/transactions/types';
 import { PageTop } from 'src/ui/components/PageTop';
+import { TokenStateSection } from 'src/ui/components/TokenStateSection';
+import type { OperationSet } from '@orb-labs/orby-core';
 
-export function TypedDataAdvancedView({ data }: { data: InterpretInput }) {
+export function TypedDataAdvancedView({
+  data,
+  operationSet,
+}: {
+  data: InterpretInput;
+  operationSet?: OperationSet;
+}) {
   return (
     <>
       <PageTop />
       <Surface padding={16} style={{ backgroundColor: 'var(--neutral-100)' }}>
         <VStack gap={16}>
+          {operationSet && (
+            <>
+              <TokenStateSection
+                title="Input Tokens"
+                tokens={operationSet.inputState}
+              />
+              <TokenStateSection
+                title="Output Tokens"
+                tokens={operationSet.outputState}
+              />
+            </>
+          )}
           {data.sections.flatMap(({ blocks }, index) =>
             blocks.map(({ name, value }) => (
               <TextLine

--- a/src/ui/shared/hooks/useOrbyGetOperationsToSignTransactionOrSignTypedData.ts
+++ b/src/ui/shared/hooks/useOrbyGetOperationsToSignTransactionOrSignTypedData.ts
@@ -6,10 +6,14 @@ import type { GasTokenInput } from 'src/ui/pages/SendTransaction/NetworkFee/Netw
 import { useOperationSetError } from './useOperationSetError';
 
 export function useOrbyGetOperationsToSignTransactionOrSignTypedData(
-  populatedTransaction: IncomingTransactionWithChainId | undefined,
+  transaction: {
+    evm: IncomingTransactionWithChainId | undefined;
+    typedData: string | undefined;
+  },
   wallet: ExternallyOwnedAccount,
   isOrbyEnabled: boolean | undefined,
-  selectedGasToken: GasTokenInput | undefined
+  selectedGasToken: GasTokenInput | undefined,
+  chainId: bigint | undefined
 ) {
   const gasToken = useMemo(() => {
     return selectedGasToken?.standardizedTokenId
@@ -17,21 +21,55 @@ export function useOrbyGetOperationsToSignTransactionOrSignTypedData(
       : undefined;
   }, [selectedGasToken]);
 
-  const { operationSet, isLoading: operationSetLoading } =
-    useGetOperationsToSignTransactionOrSignTypedData(
-      populatedTransaction?.data as string,
-      populatedTransaction?.to as string,
-      populatedTransaction?.value
-        ? BigInt(populatedTransaction?.value.toString())
-        : undefined,
-      isOrbyEnabled ? (wallet?.address as string) : undefined,
-      isOrbyEnabled && populatedTransaction?.chainId
-        ? BigInt(populatedTransaction?.chainId as number)
-        : undefined,
-      gasToken
-    );
+  const orbyParams = useMemo(() => {
+    if (!isOrbyEnabled) {
+      return { data: undefined as unknown as string };
+    } else if (transaction.evm) {
+      return {
+        data: transaction.evm?.data as string,
+        to: transaction.evm?.to as string,
+        value: transaction.evm?.value
+          ? BigInt(transaction.evm?.value?.toString())
+          : undefined,
+        entrypointAccountAddress: wallet?.address as string,
+        chainId,
+        gasToken,
+      };
+    } else if (transaction.typedData) {
+      return {
+        data: transaction.typedData as string,
+        entrypointAccountAddress: wallet?.address as string,
+        chainId,
+        gasToken,
+      };
+    } else {
+      return { data: undefined as unknown as string };
+    }
+  }, [transaction, isOrbyEnabled, chainId, wallet, gasToken]);
+
+  const {
+    operationSet,
+    isLoading: operationSetLoading,
+    operations,
+    virtualNode,
+    aggregateFee,
+  } = useGetOperationsToSignTransactionOrSignTypedData(
+    orbyParams?.data,
+    orbyParams?.to,
+    orbyParams?.value,
+    orbyParams?.entrypointAccountAddress,
+    orbyParams?.chainId,
+    orbyParams.gasToken
+  );
 
   const operationSetError = useOperationSetError(operationSet, isOrbyEnabled);
 
-  return { operationSet, operationSetError, operationSetLoading };
+  return {
+    operationSet,
+    operationSetError,
+    operationSetLoading,
+    operations,
+    virtualNode,
+    aggregateFee,
+  };
 }


### PR DESCRIPTION
This PR is step 3 of the steps to add Orby and support 1-click transactions and gas abstraction on the Zerion Chrome Extension. The same steps and similar code can be used on other Chrome Extension wallets.


[✅] Step 0 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/4) : Setup feature flags
- create a remotely configurable feature flag called `one_click_transactions_and_gas_abstraction`
- we will use this feature flag to gate access to the one click transactions and gas abstraction as we do progressive rollout of the feature.
- Zerion uses firebase but you can feature flag system of your choice such as launch darkly

[✅]  Step 1 [(No PR needed)]: Get EVM and SVM testing accounts and set them up. 
- The accounts need to have some funds, though they do not need to be native funds but at least USDC on the chain you want to test on.
- Delete all approvals for EVM accounts using something like revoke cash (https://revoke.cash/)
- Add your accounts to the flag test / development group of the feature created above

[✅]  Step 2 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/5): Get the Orby API keys for an instance and add them to your environment variables.
- The team will give you keys and urls that look like:

        ORBY_PRIVATE_API_KEY=
        ORBY_PUBLIC_API_KEY=
        ORBY_BASE_URL=


- Note: the private and public keys correspond to a particular instance with specific features enabled on that instance. Given that we're working on 1-click transactions and gas abstraction, make sure that only those 2 features are be enabled.

[✅] Step 3 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/6): Add OrbyProvider to the root of your app
- add the @orb-labs/orby-react npm package
- move some components around so that we can add `OrbyProvider` easily
- initialize the OrbyProvider using the current wallet address
- `OrbyProvider`: Adding OrbyProvider to the root of the app setups all the context and variables that will be used in hooks and function calls to communicate with Orby. 
- Note: If you prefer not to use the Orby React package, you can also create your own functions and classes for calling Orby and setting/managing up context; we're also happy to walk you through the process / code if that's preferred.

[✅] Step 4 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/7): Configure Orby to handle communication with app frontends
- this is perhaps the most involved step of the integration. Generally, we want to inject scripts to into dapps that the user is connected to, and remove it when the user disconnect from the app. 
- Also, we need to use virtual node for all node requests (e.g. `eth_call`) that are routed to the apps from the wallet (some apps do this).
1. make sure the extension has the right permissions. Most extensions have them already so, you probably do not need to do anything but you need  `"activeTab"`, `"scripting"`, and `unlimitedStorage` permissions in the `src/manifest.json` file
2. add webpage.js and core-webpage.js to the manifest's web_accessible_resources
3. add core-webpage-injector.js to the manifest's content_scripts 
4. In your package.json add a command to copy the webpage.min.js to webpage.js, core_webpage.min.js to core-webpage.js and core_webpage_injector.min.js to core-webpage-injector.js. Put this files in the location where they can be build together with other content script files or you can copy them directly into the location of the content script files after build has completed. For Zerion extension, we add them to the `./src/content-script/` before building, and meaning the files are build together with the other content script files.
5. Call the `unifyBalancesOnApps` function your background script with the first argument being the location of the files from step 4 above relative to the root of the build output directory
7. Whenever the app starts get all active app sessions and then call the `useBulkConnectAppSessions` to register them to the background script. Similarly, call the `getVirtualNodeRpcUrlsForSupportedChains` function to get virtual nodes, and add them to your RPC state as the primary way to forward RPC requests from apps the orby. This is necessary because some apps still call wallets for balances, and even generic `eth_calls`.  For the Zerion Extension, this is done in the new `RegisterSessions` component, which is conditionally rendered if the feature flag is set.
9. Whenever a app is connected to the wallet, call the updateConnectedAppSession function
10. Whenever a app is disconnected to the wallet, call the removeConnectedAppSession function 

Testing: At this point, we want to test that the wallet is function as expected.
1. Testing gas abstraction:
- `Control:` Using the Zerion wallet on App store, connect to uniswap with an account that does not have native funds on a chain like BNB Chain, ETH Mainnet, Arbitrum, Base or Optimism.  You should be blocked with a "Insufficient funds for gas" error when you attempt a swap.
- `Orby Enabled:` Now, switch to this Orby enabled Zerion wallet but with the same account. You should not be blocked with a "Insufficient funds for gas" any error when you attempt a swap, and instead you should be able to send the transaction to the wallet for signing.
1. Testing 1-click transactions:
- `Control:` Using the Zerion wallet on App store, connect to uniswap with an account with sufficient funds on a chain like BNB Chain, ETH Mainnet, Arbitrum, Base or Optimism, and attempt a swap with an ERC20 token (e.g. USDC) that has not been approved on uniswap. You should see an "Approve and Swap" CTA when you attempt to swap. Clicking the button sends an ERC20 approval request to the wallet. 
- `Orby Enabled:` Now, switch to this Orby enabled Zerion wallet but with the same account. You should see "Swap" with no approvals needed. Clicking the CTA sends a permit2 typedData to the wallet and not an approval transaction.


[✅] Step 5 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/8): Ping Orby to get  operations for every send transaction from apps
- We add a `useIsOrbyEnabled` hook to check if a chain is orby enabled and if a user has the feature flag enabled
- if orby is enabled, we call the `useGetOperationsToExecuteTransaction` with the transaction data from the user.
- Once we get the operations from Orby, we display them to the user under the details tab
- we also allow the user to pick custom gas tokens from the list of tokens that the user has

Testing: 
- connect to uniswap and initiate a transaction. 
- when the transaction is rendered by the wallet, there should be a way to pick a gas token based on the balances you have on that chain (as shown below)
<img width="357" height="147" alt="Screenshot 2025-07-15 at 01 54 22" src="https://github.com/user-attachments/assets/f00a9e11-9a4c-43ba-9aa4-000346017d15" />

- when you click the details tab, you should see the tokens going in and out of your account
<img width="355" height="237" alt="Screenshot 2025-07-15 at 01 54 56" src="https://github.com/user-attachments/assets/b4cabd5d-d7c6-4055-b047-1fd30dbb50ec" />


- when you click the gas dropdown, you should be able to choose the token of choice for paying for gas
<img width="358" height="480" alt="Screenshot 2025-07-15 at 01 56 33" src="https://github.com/user-attachments/assets/18af3299-cdba-47c0-8073-25fcd6f94aa1" />


- when a custom gas token is chosen, the native token does not show on the input tokens of the details page (e.g. the image below using DAI).
<img width="358" height="267" alt="Screenshot 2025-07-15 at 01 58 36" src="https://github.com/user-attachments/assets/e92a0bef-637c-4d8b-9d42-8c9eb4681575" />


- if you pick a token that is not enough to pay for gas or if there is not enough native tokens for gas, an error is shown
<img width="349" height="215" alt="Screenshot 2025-07-15 at 01 59 50" src="https://github.com/user-attachments/assets/e0aa144e-48fe-4984-84e3-268c30de3126" />


[👉] Step 6: Ping Orby to get  operations for signTypedData call from apps
- We use`useIsOrbyEnabled` hook to check if a chain is orby enabled and if a user has the feature flag enabled
- if orby is enabled, we call the `useGetOperationsToSignTransactionOrSignTypedData` with the typeddata from the user.
- Once we get the operations from Orby, we display them to the user under the details tab
- we also allow the user to pick custom gas tokens from the list of tokens that the user has

Testing: `Follow the same steps as those above but using typeddata instead`. Use Uniswap or Morpho for testing

