### PR TITLE
1-click+gas-step 8: sign and submit operations

### DIFF
--- a/src/shared/core/orb.ts
+++ b/src/shared/core/orb.ts
@@ -1,0 +1,56 @@
+import type { OnchainOperation, UserOperation } from '@orb-labs/orby-core';
+import { OperationDataFormat } from '@orb-labs/orby-core';
+import type { TypedDataDomain, TypedDataField } from 'ethers';
+import { walletPort } from 'src/ui/shared/channels';
+
+async function signOperation(operation: OnchainOperation): Promise<string> {
+  if (operation.format == OperationDataFormat.TRANSACTION) {
+    const txData = {
+      from: operation.from,
+      to: operation.to,
+      value: operation.value ? operation.value.toString() : undefined,
+      data: operation.data,
+      nonce: operation.nonce ? Number(operation.nonce) : undefined,
+      gasLimit: operation?.gasLimit?.toString(),
+      chainId: operation.chainId ? Number(operation.chainId) : undefined,
+      gasPrice: operation?.gasPrice?.toString(),
+      maxFeePerGas: operation?.maxFeePerGas?.toString(),
+      maxPriorityFeePerGas: operation?.maxPriorityFeePerGas?.toString(),
+    };
+
+    return (await walletPort.request('signTransaction', [txData])) as string;
+  } else {
+    const parsedData = JSON.parse(operation.data) as {
+      domain: TypedDataDomain;
+      types: Record<string, Array<TypedDataField>>;
+      message: Record<string, any>;
+    };
+
+    delete parsedData.types['EIP712Domain'];
+    return (await walletPort.request('signTypedData', {
+      typedData: parsedData,
+    })) as string;
+  }
+}
+
+export async function signTransaction(
+  operation: OnchainOperation
+): Promise<string | undefined> {
+  return await signOperation(operation);
+}
+
+export async function signUserOperation(
+  _operations: OnchainOperation[],
+  _accountAddress: string,
+  _chainId: bigint,
+  _txRpcUrl: string
+): Promise<UserOperation | undefined> {
+  // TODO: Implement user operation signing logic
+  return undefined;
+}
+
+export async function signTypedData(
+  operation: OnchainOperation
+): Promise<string | undefined> {
+  return await signOperation(operation);
+}

--- a/src/ui/components/SignMessageButton/SignMessageButton.tsx
+++ b/src/ui/components/SignMessageButton/SignMessageButton.tsx
@@ -45,12 +45,14 @@ export const SignMessageButton = React.forwardRef(function SignMessageButton(
     buttonKind = 'primary',
     onClick,
     holdToSign,
+    submitOperationSetIsLoading,
     ...buttonProps
   }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
     wallet: ExternallyOwnedAccount;
     buttonTitle?: React.ReactNode;
     buttonKind?: ButtonKind;
     holdToSign: boolean | null;
+    submitOperationSetIsLoading?: boolean;
   },
   ref: React.Ref<SignMsgBtnHandle>
 ) {
@@ -169,7 +171,7 @@ export const SignMessageButton = React.forwardRef(function SignMessageButton(
             submittingText="Sending..."
             onClick={handleClick}
             success={isSuccess}
-            submitting={isLoading}
+            submitting={isLoading || submitOperationSetIsLoading}
             disabled={disabled}
             error={isError}
             kind={buttonKind}
@@ -177,7 +179,7 @@ export const SignMessageButton = React.forwardRef(function SignMessageButton(
           />
         ) : (
           <Button
-            disabled={disabled}
+            disabled={disabled || submitOperationSetIsLoading}
             onClick={handleClick}
             kind={buttonKind}
             {...buttonProps}

--- a/src/ui/pages/SendTransaction/SendTransaction.tsx
+++ b/src/ui/pages/SendTransaction/SendTransaction.tsx
@@ -99,8 +99,18 @@ import ScrollIcon from 'jsx:src/ui/assets/scroll.svg';
 import ArrowDownIcon from 'jsx:src/ui/assets/caret-down-filled.svg';
 import { SiteFaviconImg } from 'src/ui/components/SiteFaviconImg';
 import { NetworkId } from 'src/modules/networks/NetworkId';
+import type { OperationStatus } from '@orb-labs/orby-core';
+import { OperationStatusType } from '@orb-labs/orby-core';
+import {
+  signUserOperation,
+  signTransaction,
+  signTypedData,
+} from 'src/shared/core/orb';
+import _ from 'lodash';
+import type { Hex } from '@noble/ed25519';
 import { useIsOrbyEnabled } from 'src/shared/core/useIsOrbyEnabled';
 import { useOrbyGetOperationsToSignTransactionOrSignTypedData } from 'src/ui/shared/hooks/useOrbyGetOperationsToSignTransactionOrSignTypedData';
+import { useOrby } from '@orb-labs/orby-react';
 import type { PopoverToastHandle } from '../Settings/PopoverToast';
 import { PopoverToast } from '../Settings/PopoverToast';
 import { TransactionConfiguration } from './TransactionConfiguration';
@@ -562,6 +572,8 @@ function SendTransactionContent({
     });
 
   const [allowanceQuantityBase, setAllowanceQuantityBase] = useState('');
+  const [submitTransactionIsLoading, setSubmitTransactionIsLoading] =
+    useState(false);
 
   const configureTransactionToBeSigned = useEvent(
     async (
@@ -604,7 +616,7 @@ function SendTransactionContent({
     [setSelectedGasToken]
   );
 
-  const { operationSet, operationSetError, operationSetLoading } =
+  const { operationSet, operationSetError, operationSetLoading, virtualNode } =
     useOrbyGetOperationsToSignTransactionOrSignTypedData(
       { evm: populatedTransaction, typedData: undefined },
       wallet,
@@ -770,6 +782,73 @@ function SendTransactionContent({
     onSuccess: (tx) => handleSentTransaction(tx),
   });
 
+  const operationStatusesUpdated = useCallback(
+    async (
+      statusSummary: OperationStatusType,
+      finalTransactionStatus?: OperationStatus,
+      _statuses?: OperationStatus[]
+    ) => {
+      if (
+        [OperationStatusType.SUCCESSFUL, OperationStatusType.PENDING].includes(
+          statusSummary
+        )
+      ) {
+        if (virtualNode && finalTransactionStatus?.hash) {
+          const receipt = await (virtualNode as any).waitForTransactionReceipt({
+            hash: finalTransactionStatus.hash as Hex,
+          });
+
+          handleSentTransaction({
+            evm: {
+              ...receipt,
+              hash: receipt.transactionHash,
+              to: receipt.to,
+              from: receipt.from,
+              value: receipt.value,
+              data: receipt.data,
+            },
+          });
+
+          setSubmitTransactionIsLoading(false);
+        }
+      }
+    },
+    [handleSentTransaction, virtualNode]
+  );
+
+  const { accountCluster } = useOrby();
+  const submitTransaction = useCallback(async () => {
+    if (isOrbyEnabled) {
+      if (accountCluster && virtualNode && virtualNode) {
+        setSubmitTransactionIsLoading(true);
+        const { operationResponses } = await virtualNode.sendOperationSet(
+          accountCluster,
+          operationSet,
+          signTransaction,
+          signUserOperation,
+          signTypedData
+        );
+
+        const ids = operationResponses
+          ?.map((op) => op.id)
+          .filter((id) => !_.isUndefined(id));
+        virtualNode?.subscribeToOperationStatuses(
+          ids,
+          operationStatusesUpdated
+        );
+      }
+    } else {
+      sendTransaction();
+    }
+  }, [
+    accountCluster,
+    operationSet,
+    virtualNode,
+    operationStatusesUpdated,
+    isOrbyEnabled,
+    sendTransaction,
+  ]);
+
   if (localAddressActionQuery.isSuccess && !localAddressAction) {
     throw new Error('Unexpected missing localAddressAction');
   }
@@ -903,14 +982,15 @@ function SendTransactionContent({
                   // (important for paymaster flow)
                   wallet={wallet}
                   ref={sendTxBtnRef}
-                  onClick={() => sendTransaction()}
+                  onClick={() => submitTransaction()}
                   isLoading={
                     sendTransactionMutation.isLoading || operationSetLoading
                   }
                   disabled={
                     sendTransactionMutation.isLoading ||
                     operationSetLoading ||
-                    !!operationSetError
+                    !!operationSetError ||
+                    submitTransactionIsLoading
                   }
                   buttonKind={
                     interpretationHasCriticalWarning ? 'danger' : 'primary'

--- a/src/ui/pages/SignTypedData/SignTypedData.tsx
+++ b/src/ui/pages/SignTypedData/SignTypedData.tsx
@@ -64,14 +64,24 @@ import {
   SecurityStatusBackground,
 } from 'src/ui/shared/security-check';
 import { INTERNAL_ORIGIN } from 'src/background/constants';
-import { useGetFungibleTokenPortfolio } from '@orb-labs/orby-react';
+import { useGetFungibleTokenPortfolio, useOrby } from '@orb-labs/orby-react';
 import { type OnchainOperation } from '@orb-labs/orby-core';
-import type { OperationSet, StandardizedBalance } from '@orb-labs/orby-core';
+import type {
+  OperationSet,
+  OperationStatus,
+  StandardizedBalance,
+} from '@orb-labs/orby-core';
+import { OperationStatusType } from '@orb-labs/orby-core';
 import type { Client } from 'viem';
 import type { HttpTransport } from 'viem';
 import type { PublicRpcSchema } from 'viem';
 import type { OrbyActions } from '@orb-labs/orby-viem-extension';
 import _ from 'lodash';
+import {
+  signTransaction,
+  signTypedData,
+  signUserOperation,
+} from 'src/shared/core/orb';
 import { useIsOrbyEnabled } from 'src/shared/core/useIsOrbyEnabled';
 import { useOrbyGetOperationsToSignTransactionOrSignTypedData } from 'src/ui/shared/hooks/useOrbyGetOperationsToSignTransactionOrSignTypedData';
 import { PopoverToast } from '../Settings/PopoverToast';
@@ -120,6 +130,8 @@ function TypedDataDefaultView({
   setSelectedGasToken,
   fungibleTokens,
   aggregateFee,
+  virtualNode,
+  operationSet,
 }: {
   origin: string;
   clientScope: string | null;
@@ -160,6 +172,9 @@ function TypedDataDefaultView({
   const { preferences } = usePreferences();
   const chainId = chain && networks ? networks.getChainId(chain) : null;
   const isOrbyEnabled = useIsOrbyEnabled(chainId ? BigInt(chainId) : undefined);
+  const { accountCluster } = useOrby();
+  const [submitOperationSetIsLoading, setSubmitOperationSetIsLoading] =
+    useState(false);
 
   const addressAction = interpretation?.action;
   const recipientAddress = addressAction?.label?.display_value.wallet_address;
@@ -214,6 +229,56 @@ function TypedDataDefaultView({
       },
     }
   );
+
+  const operationStatusesUpdated = useCallback(
+    async (
+      statusSummary: OperationStatusType,
+      _finalTransactionStatus?: OperationStatus,
+      _statuses?: OperationStatus[]
+    ) => {
+      if (
+        [OperationStatusType.SUCCESSFUL, OperationStatusType.PENDING].includes(
+          statusSummary
+        )
+      ) {
+        signTypedData_v4();
+        setSubmitOperationSetIsLoading(false);
+      }
+    },
+    [signTypedData_v4]
+  );
+
+  const submitTransaction = useCallback(async () => {
+    if (isOrbyEnabled) {
+      if (accountCluster && virtualNode && virtualNode) {
+        setSubmitOperationSetIsLoading(true);
+        const { operationResponses } = await virtualNode.sendOperationSet(
+          accountCluster,
+          operationSet,
+          signTransaction,
+          signUserOperation,
+          signTypedData
+        );
+
+        const ids = operationResponses
+          ?.map((op) => op.id)
+          .filter((id) => !_.isUndefined(id));
+        virtualNode?.subscribeToOperationStatuses(
+          ids,
+          operationStatusesUpdated
+        );
+      }
+    } else {
+      signTypedData_v4();
+    }
+  }, [
+    accountCluster,
+    operationSet,
+    virtualNode,
+    operationStatusesUpdated,
+    isOrbyEnabled,
+    signTypedData_v4,
+  ]);
 
   const interpretationHasCriticalWarning = hasCriticalWarning(
     interpretation?.warnings
@@ -489,7 +554,7 @@ function TypedDataDefaultView({
                   wallet={wallet}
                   ref={signMsgBtnRef}
                   onClick={() => {
-                    signTypedData_v4();
+                    submitTransaction();
                   }}
                   buttonKind={
                     interpretationHasCriticalWarning ? 'danger' : 'primary'
@@ -500,6 +565,7 @@ function TypedDataDefaultView({
                       : undefined
                   }
                   holdToSign={preferences.enableHoldToSignButton}
+                  submitOperationSetIsLoading={submitOperationSetIsLoading}
                 />
               ) : null}
             </div>
@@ -535,6 +601,7 @@ function SignTypedDataContent({
   invariant(windowId, 'windowId get-parameter is required');
 
   const navigate = useNavigate();
+  // const { preferences } = usePreferences();
 
   const [allowanceQuantityBase, setAllowanceQuantityBase] = useState('');
 

--- a/src/ui/pages/SignTypedData/SignTypedData.tsx
+++ b/src/ui/pages/SignTypedData/SignTypedData.tsx
@@ -601,7 +601,6 @@ function SignTypedDataContent({
   invariant(windowId, 'windowId get-parameter is required');
 
   const navigate = useNavigate();
-  // const { preferences } = usePreferences();
 
   const [allowanceQuantityBase, setAllowanceQuantityBase] = useState('');
 


### PR DESCRIPTION
This PR is step 3 of the steps to add Orby and support 1-click transactions and gas abstraction on the Zerion Chrome Extension. The same steps and similar code can be used on other Chrome Extension wallets.


[✅] Step 0 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/4) : Setup feature flags
- create a remotely configurable feature flag called `one_click_transactions_and_gas_abstraction`
- we will use this feature flag to gate access to the one click transactions and gas abstraction as we do progressive rollout of the feature.
- Zerion uses firebase but you can feature flag system of your choice such as launch darkly

[✅]  Step 1 [(No PR needed)]: Get EVM and SVM testing accounts and set them up. 
- The accounts need to have some funds, though they do not need to be native funds but at least USDC on the chain you want to test on.
- Delete all approvals for EVM accounts using something like revoke cash (https://revoke.cash/)
- Add your accounts to the flag test / development group of the feature created above

[✅]  Step 2 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/5): Get the Orby API keys for an instance and add them to your environment variables.
- The team will give you keys and urls that look like:

        ORBY_PRIVATE_API_KEY=
        ORBY_PUBLIC_API_KEY=
        ORBY_BASE_URL=


- Note: the private and public keys correspond to a particular instance with specific features enabled on that instance. Given that we're working on 1-click transactions and gas abstraction, make sure that only those 2 features are be enabled.

[✅] Step 3 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/6): Add OrbyProvider to the root of your app
- add the @orb-labs/orby-react npm package
- move some components around so that we can add `OrbyProvider` easily
- initialize the OrbyProvider using the current wallet address
- `OrbyProvider`: Adding OrbyProvider to the root of the app setups all the context and variables that will be used in hooks and function calls to communicate with Orby. 
- Note: If you prefer not to use the Orby React package, you can also create your own functions and classes for calling Orby and setting/managing up context; we're also happy to walk you through the process / code if that's preferred.

[✅] Step 4 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/7): Configure Orby to handle communication with app frontends
- this is perhaps the most involved step of the integration. Generally, we want to inject scripts to into dapps that the user is connected to, and remove it when the user disconnect from the app. 
- Also, we need to use virtual node for all node requests (e.g. `eth_call`) that are routed to the apps from the wallet (some apps do this).
1. make sure the extension has the right permissions. Most extensions have them already so, you probably do not need to do anything but you need  `"activeTab"`, `"scripting"`, and `unlimitedStorage` permissions in the `src/manifest.json` file
2. add webpage.js and core-webpage.js to the manifest's web_accessible_resources
3. add core-webpage-injector.js to the manifest's content_scripts 
4. In your package.json add a command to copy the webpage.min.js to webpage.js, core_webpage.min.js to core-webpage.js and core_webpage_injector.min.js to core-webpage-injector.js. Put this files in the location where they can be build together with other content script files or you can copy them directly into the location of the content script files after build has completed. For Zerion extension, we add them to the `./src/content-script/` before building, and meaning the files are build together with the other content script files.
5. Call the `unifyBalancesOnApps` function your background script with the first argument being the location of the files from step 4 above relative to the root of the build output directory
7. Whenever the app starts get all active app sessions and then call the `useBulkConnectAppSessions` to register them to the background script. Similarly, call the `getVirtualNodeRpcUrlsForSupportedChains` function to get virtual nodes, and add them to your RPC state as the primary way to forward RPC requests from apps the orby. This is necessary because some apps still call wallets for balances, and even generic `eth_calls`.  For the Zerion Extension, this is done in the new `RegisterSessions` component, which is conditionally rendered if the feature flag is set.
9. Whenever a app is connected to the wallet, call the updateConnectedAppSession function
10. Whenever a app is disconnected to the wallet, call the removeConnectedAppSession function 

Testing: At this point, we want to test that the wallet is function as expected.
1. Testing gas abstraction:
- `Control:` Using the Zerion wallet on App store, connect to uniswap with an account that does not have native funds on a chain like BNB Chain, ETH Mainnet, Arbitrum, Base or Optimism.  You should be blocked with a "Insufficient funds for gas" error when you attempt a swap.
- `Orby Enabled:` Now, switch to this Orby enabled Zerion wallet but with the same account. You should not be blocked with a "Insufficient funds for gas" any error when you attempt a swap, and instead you should be able to send the transaction to the wallet for signing.
1. Testing 1-click transactions:
- `Control:` Using the Zerion wallet on App store, connect to uniswap with an account with sufficient funds on a chain like BNB Chain, ETH Mainnet, Arbitrum, Base or Optimism, and attempt a swap with an ERC20 token (e.g. USDC) that has not been approved on uniswap. You should see an "Approve and Swap" CTA when you attempt to swap. Clicking the button sends an ERC20 approval request to the wallet. 
- `Orby Enabled:` Now, switch to this Orby enabled Zerion wallet but with the same account. You should see "Swap" with no approvals needed. Clicking the CTA sends a permit2 typedData to the wallet and not an approval transaction.


[✅] Step 5 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/8): Ping Orby to get  operations for every send transaction from apps
- We add a `useIsOrbyEnabled` hook to check if a chain is orby enabled and if a user has the feature flag enabled
- if orby is enabled, we call the `useGetOperationsToExecuteTransaction` with the transaction data from the user.
- Once we get the operations from Orby, we display them to the user under the details tab
- we also allow the user to pick custom gas tokens from the list of tokens that the user has

Testing: 
- connect to uniswap and initiate a transaction. 
- when the transaction is rendered by the wallet, there should be a way to pick a gas token based on the balances you have on that chain (as shown below)
<img width="357" height="147" alt="Screenshot 2025-07-15 at 01 54 22" src="https://github.com/user-attachments/assets/f00a9e11-9a4c-43ba-9aa4-000346017d15" />

- when you click the details tab, you should see the tokens going in and out of your account
<img width="355" height="237" alt="Screenshot 2025-07-15 at 01 54 56" src="https://github.com/user-attachments/assets/b4cabd5d-d7c6-4055-b047-1fd30dbb50ec" />


- when you click the gas dropdown, you should be able to choose the token of choice for paying for gas
<img width="358" height="480" alt="Screenshot 2025-07-15 at 01 56 33" src="https://github.com/user-attachments/assets/18af3299-cdba-47c0-8073-25fcd6f94aa1" />


- when a custom gas token is chosen, the native token does not show on the input tokens of the details page (e.g. the image below using DAI).
<img width="358" height="267" alt="Screenshot 2025-07-15 at 01 58 36" src="https://github.com/user-attachments/assets/e92a0bef-637c-4d8b-9d42-8c9eb4681575" />


- if you pick a token that is not enough to pay for gas or if there is not enough native tokens for gas, an error is shown
<img width="349" height="215" alt="Screenshot 2025-07-15 at 01 59 50" src="https://github.com/user-attachments/assets/e0aa144e-48fe-4984-84e3-268c30de3126" />


[✅] Step 6 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/9): Ping Orby to get  operations for every send transaction from apps
- We use`useIsOrbyEnabled` hook to check if a chain is orby enabled and if a user has the feature flag enabled
- if orby is enabled, we call the `useGetOperationsToSignTransactionOrSignTypedData` with the typeddata from the user.
- Once we get the operations from Orby, we display them to the user under the details tab
- we also allow the user to pick custom gas tokens from the list of tokens that the user has

Testing: `Follow the same steps as those above but using typeddata instead`. Use Uniswap or Morpho for testing

[❌] Step 7: Verify operations using transaction verification systems such as Blockaid.


[👉] Step 8: Sign and submit operations
- Create a functions that can be used to sign operations. For signing, we iterate through the operations and sign them one by one. To the user, it seems like they just signed one transaction. We create the `signOperation`, `signTransaction`, and signUserOperation functions in `src/shared/core/orb.ts` file. The functions call the actual wallet signing functions in `src/background/Wallet/Wallet.ts`.
- When the user clicks submit or sign, send operations to Orby using the virtual nodes’ ‘sendOperationSet’ function
- Subscribe to the statuses of these operations from Orby using the `subscribeToOperationStatuses` function
- When the final operation has been successfully submitted, return the result to the user




