### PR TITLE
1-click+gas-step 9: fetch and show batched operations

### DIFF
--- a/src/ui/pages/History/ActivityList.tsx
+++ b/src/ui/pages/History/ActivityList.tsx
@@ -1,0 +1,359 @@
+import React, { useMemo, useState, useRef } from 'react';
+import groupBy from 'lodash/groupBy';
+import { startOfDate } from 'src/shared/units/startOfDate';
+import { VStack } from 'src/ui/ui-kit/VStack';
+import { UIText } from 'src/ui/ui-kit/UIText';
+import { SurfaceList } from 'src/ui/ui-kit/SurfaceList';
+import { ViewLoading } from 'src/ui/components/ViewLoading';
+import { HStack } from 'src/ui/ui-kit/HStack';
+import { DelayedRender } from 'src/ui/components/DelayedRender';
+import { Media } from 'src/ui/ui-kit/Media';
+import type { Activity } from '@orb-labs/orby-core';
+import { CircleSpinner } from 'src/ui/ui-kit/CircleSpinner';
+import { CenteredDialog } from 'src/ui/ui-kit/ModalDialogs/CenteredDialog';
+import { Button } from 'src/ui/ui-kit/Button';
+import { Surface } from 'src/ui/ui-kit/Surface';
+import { TokenStateSection } from 'src/ui/components/TokenStateSection/TokenStateSection';
+
+const ACTIVITY_ICON_SIZE = 36;
+
+// Map activity categories to user-friendly labels and emoji icons
+const CATEGORY_LABELS: Record<string, string> = {
+  FUNCTION_CALL: 'Function Call',
+  TRADE: 'Trade',
+  APPROVE: 'Approve',
+  TRANSFER: 'Transfer',
+  // Add more mappings as needed
+};
+
+const CATEGORY_ICONS: Record<string, React.ReactNode> = {
+  FUNCTION_CALL: (
+    <div
+      style={{
+        width: ACTIVITY_ICON_SIZE,
+        height: ACTIVITY_ICON_SIZE,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 28,
+      }}
+    >
+      📝
+    </div>
+  ),
+  // Add more mappings as needed
+};
+
+function getCategoryLabel(category: string | undefined) {
+  if (!category) return 'Activity';
+  return (
+    CATEGORY_LABELS[category] ||
+    category.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+  );
+}
+
+function getCategoryIcon(category: string | undefined) {
+  if (!category)
+    return (
+      <div
+        style={{
+          width: ACTIVITY_ICON_SIZE,
+          height: ACTIVITY_ICON_SIZE,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 28,
+        }}
+      >
+        ✅
+      </div>
+    );
+  return (
+    CATEGORY_ICONS[category] || (
+      <div
+        style={{
+          width: ACTIVITY_ICON_SIZE,
+          height: ACTIVITY_ICON_SIZE,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 28,
+        }}
+      >
+        ✅
+      </div>
+    )
+  );
+}
+
+function getStatusColor(status: string | undefined) {
+  if (!status) return undefined;
+  if (status === 'FAILED') return 'var(--negative-500)';
+  if (status === 'WAITING_TIMEOUT' || status === 'PENDING')
+    return 'var(--notice-500)';
+  if (status === 'SUCCESS') return 'var(--positive-500)';
+  return undefined;
+}
+
+const dateFormatter = new Intl.DateTimeFormat('en', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+});
+
+function ActivityDetailedView({
+  activity,
+  onClose,
+}: {
+  activity: Activity;
+  onClose: () => void;
+}) {
+  const firstOperation = activity.operationStatuses[0];
+  const date = activity.initiateAt
+    ? dateFormatter.format(new Date(activity.initiateAt))
+    : '';
+  return (
+    <VStack
+      gap={14}
+      style={{ ['--surface-background-color' as string]: 'var(--white)' }}
+    >
+      <Button
+        kind="ghost"
+        value="cancel"
+        size={40}
+        style={{
+          width: 40,
+          padding: 8,
+          position: 'absolute',
+          top: 16,
+          left: 8,
+        }}
+        onClick={onClose}
+      >
+        ←
+      </Button>
+      <VStack gap={0} style={{ justifyItems: 'center' }}>
+        <UIText kind="body/accent" style={{ fontWeight: 600, fontSize: 22 }}>
+          {getCategoryLabel(activity.category)}
+        </UIText>
+        {date && (
+          <UIText kind="small/regular" color="var(--neutral-500)">
+            {date}
+          </UIText>
+        )}
+      </VStack>
+      <VStack gap={4}>
+        <TokenStateSection title="Send" tokens={activity.inputState} />
+        <TokenStateSection title="Receive" tokens={activity.outputState} />
+      </VStack>
+      <Surface padding={16}>
+        <VStack gap={16}>
+          {firstOperation?.hash && (
+            <HStack gap={8} alignItems="center">
+              <UIText kind="small/accent">Hash:</UIText>
+              <UIText kind="small/regular" style={{ wordBreak: 'break-all' }}>
+                {firstOperation.hash}
+              </UIText>
+            </HStack>
+          )}
+          <HStack gap={8} alignItems="center">
+            <UIText kind="small/accent">Status:</UIText>
+            <UIText kind="small/regular">{activity.overallStatus}</UIText>
+          </HStack>
+        </VStack>
+      </Surface>
+    </VStack>
+  );
+}
+
+function ActivityItem({ activity }: { activity: Activity }) {
+  const [open, setOpen] = useState(false);
+  const dialogRef = useRef(null);
+  const status = activity.overallStatus;
+  const category = activity.category;
+  const label = getCategoryLabel(category);
+  const icon = getCategoryIcon(category);
+  const statusColor = getStatusColor(status);
+  const firstOperation = activity.operationStatuses[0];
+  const hash = firstOperation?.hash;
+  const isFailed = status === 'FAILED';
+  const isPending = status === 'WAITING_TIMEOUT' || status === 'PENDING';
+
+  // Value display
+  const value = activity.aggregateFiatValueOfOutputState;
+  const valueColor =
+    value && Number(value.toFixed()) > 0 ? 'var(--positive-500)' : undefined;
+
+  return (
+    <>
+      <div style={{ cursor: 'pointer' }} onClick={() => setOpen(true)}>
+        <Media
+          vGap={0}
+          gap={12}
+          image={
+            isFailed ? (
+              <div
+                style={{
+                  width: ACTIVITY_ICON_SIZE,
+                  height: ACTIVITY_ICON_SIZE,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 28,
+                }}
+              >
+                ❌
+              </div>
+            ) : isPending ? (
+              <div
+                style={{
+                  width: ACTIVITY_ICON_SIZE,
+                  height: ACTIVITY_ICON_SIZE,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <CircleSpinner
+                  size={ACTIVITY_ICON_SIZE + 'px'}
+                  color="var(--primary)"
+                />
+              </div>
+            ) : (
+              icon
+            )
+          }
+          text={
+            <UIText kind="body/accent" style={{ fontWeight: 600 }}>
+              {label}
+            </UIText>
+          }
+          detailText={
+            <VStack gap={2} style={{ alignItems: 'flex-end', minWidth: 80 }}>
+              <HStack gap={8} alignItems="center">
+                <UIText
+                  kind="small/regular"
+                  color={statusColor}
+                  style={{ fontWeight: 500 }}
+                >
+                  {status || 'Unknown Status'}
+                </UIText>
+                {hash && (
+                  <UIText kind="caption/regular" color="var(--neutral-400)">
+                    {hash.slice(0, 8)}...{hash.slice(-6)}
+                  </UIText>
+                )}
+              </HStack>
+              {value && (
+                <UIText
+                  kind="body/accent"
+                  color={valueColor}
+                  style={{ fontWeight: 600 }}
+                >
+                  ${value.toFixed(2)}
+                </UIText>
+              )}
+              {value && (
+                <UIText kind="small/regular" color="var(--neutral-500)">
+                  {value.currency.symbol}
+                </UIText>
+              )}
+            </VStack>
+          }
+        />
+      </div>
+      <CenteredDialog
+        ref={dialogRef}
+        open={open}
+        onClose={() => setOpen(false)}
+        containerStyle={{ backgroundColor: 'var(--neutral-100)' }}
+        renderWhenOpen={() => (
+          <ActivityDetailedView
+            activity={activity}
+            onClose={() => setOpen(false)}
+          />
+        )}
+      />
+    </>
+  );
+}
+
+export function ActivityList({
+  activities,
+  hasMore,
+  isLoading,
+  onLoadMore,
+}: {
+  activities: Activity[];
+  hasMore: boolean;
+  isLoading: boolean;
+  onLoadMore?(): void;
+}) {
+  const groupedByDate = useMemo(
+    () =>
+      groupBy(activities, (item) =>
+        startOfDate(
+          item.initiateAt ? new Date(item.initiateAt).getTime() : Date.now()
+        ).getTime()
+      ),
+    [activities]
+  );
+
+  return (
+    <VStack gap={4} style={{ alignContent: 'start' }}>
+      <VStack gap={24}>
+        {Object.entries(groupedByDate).map(([timestamp, items]) => (
+          <VStack gap={8} key={timestamp}>
+            <HStack
+              gap={8}
+              justifyContent="space-between"
+              style={{ paddingInline: 16 }}
+            >
+              <UIText kind="small/accent">
+                {new Intl.DateTimeFormat('en', {
+                  dateStyle: 'medium',
+                }).format(Number(timestamp))}{' '}
+              </UIText>
+            </HStack>
+            <SurfaceList
+              gap={4}
+              items={items.map((activity, index) => {
+                const key = `activity-${index}-${
+                  activity.initiateAt
+                    ? new Date(activity.initiateAt).getTime()
+                    : Date.now()
+                }`;
+                return {
+                  key,
+                  component: <ActivityItem activity={activity} />,
+                };
+              })}
+            />
+          </VStack>
+        ))}
+      </VStack>
+      {activities.length && (isLoading || hasMore) ? (
+        <SurfaceList
+          items={[
+            {
+              key: 0,
+              onClick: isLoading ? undefined : onLoadMore,
+              style: { height: 40 },
+              component: isLoading ? (
+                <DelayedRender delay={400}>
+                  <ViewLoading />
+                </DelayedRender>
+              ) : (
+                <UIText kind="body/accent" color="var(--primary)">
+                  Show More
+                </UIText>
+              ),
+            },
+          ]}
+        />
+      ) : null}
+    </VStack>
+  );
+}

--- a/src/ui/pages/History/History.tsx
+++ b/src/ui/pages/History/History.tsx
@@ -27,7 +27,11 @@ import {
   offsetValues,
 } from 'src/ui/pages/Overview/getTabsOffset';
 import { getAddressType } from 'src/shared/wallet/classifiers';
+import { useGetActivity } from '@orb-labs/orby-react';
+import { usePreferences } from 'src/ui/features/preferences';
+import { useIsOrbyEnabled } from 'src/shared/core/useIsOrbyEnabled';
 import { ActionsList } from './ActionsList';
+import { ActivityList } from './ActivityList';
 import { ActionSearch } from './ActionSearch';
 import { isMatchForAllWords } from './matchSearcQuery';
 
@@ -195,6 +199,7 @@ export function HistoryList({
   const offsetValuesState = useStore(offsetValues);
   const addressType = getAddressType(address);
   const showNetworkSelector = addressType === 'evm';
+  const { preferences } = usePreferences();
 
   const chainValue = selectedChain || dappChain || NetworkSelectValue.All;
   const chain =
@@ -209,6 +214,12 @@ export function HistoryList({
     fetchMore,
     hasMore,
   } = useMinedAndPendingAddressActions({ chain, searchQuery });
+
+  const { networks } = useNetworks();
+  const chainId = chain ? networks?.getChainId(chain) : undefined;
+  const isOrbyEnabled = useIsOrbyEnabled(chainId ? BigInt(chainId) : undefined);
+
+  const { activity } = useGetActivity(preferences?.testnetMode?.on ?? false);
 
   const actionFilters = (
     <div style={{ paddingInline: 16 }}>
@@ -263,6 +274,13 @@ export function HistoryList({
     <>
       {actionFilters}
       <Spacer height={16} />
+      {isOrbyEnabled && activity?.activities ? (
+        <ActivityList
+          activities={activity?.activities}
+          hasMore={activity?.pageInfo?.hasNextPage}
+          isLoading={false}
+        />
+      ) : undefined}
       <ActionsList
         actions={transactions}
         hasMore={hasMore}

--- a/src/ui/pages/History/History.tsx
+++ b/src/ui/pages/History/History.tsx
@@ -219,7 +219,10 @@ export function HistoryList({
   const chainId = chain ? networks?.getChainId(chain) : undefined;
   const isOrbyEnabled = useIsOrbyEnabled(chainId ? BigInt(chainId) : undefined);
 
-  const { activity } = useGetActivity(preferences?.testnetMode?.on ?? false);
+  const { activity } = useGetActivity(
+    preferences?.testnetMode?.on ?? false,
+    chainId ? BigInt(chainId) : undefined
+  );
 
   const actionFilters = (
     <div style={{ paddingInline: 16 }}>

--- a/src/ui/pages/SignTypedData/SignTypedData.tsx
+++ b/src/ui/pages/SignTypedData/SignTypedData.tsx
@@ -601,6 +601,7 @@ function SignTypedDataContent({
   invariant(windowId, 'windowId get-parameter is required');
 
   const navigate = useNavigate();
+  // const { preferences } = usePreferences();
 
   const [allowanceQuantityBase, setAllowanceQuantityBase] = useState('');
 


### PR DESCRIPTION
This PR is step 3 of the steps to add Orby and support 1-click transactions and gas abstraction on the Zerion Chrome Extension. The same steps and similar code can be used on other Chrome Extension wallets.


[✅] Step 0 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/4) : Setup feature flags
- create a remotely configurable feature flag called `one_click_transactions_and_gas_abstraction`
- we will use this feature flag to gate access to the one click transactions and gas abstraction as we do progressive rollout of the feature.
- Zerion uses firebase but you can feature flag system of your choice such as launch darkly

[✅]  Step 1 [(No PR needed)]: Get EVM and SVM testing accounts and set them up. 
- The accounts need to have some funds, though they do not need to be native funds but at least USDC on the chain you want to test on.
- Delete all approvals for EVM accounts using something like revoke cash (https://revoke.cash/)
- Add your accounts to the flag test / development group of the feature created above

[✅]  Step 2 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/5): Get the Orby API keys for an instance and add them to your environment variables.
- The team will give you keys and urls that look like:

        ORBY_PRIVATE_API_KEY=
        ORBY_PUBLIC_API_KEY=
        ORBY_BASE_URL=


- Note: the private and public keys correspond to a particular instance with specific features enabled on that instance. Given that we're working on 1-click transactions and gas abstraction, make sure that only those 2 features are be enabled.

[✅] Step 3 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/6): Add OrbyProvider to the root of your app
- add the @orb-labs/orby-react npm package
- move some components around so that we can add `OrbyProvider` easily
- initialize the OrbyProvider using the current wallet address
- `OrbyProvider`: Adding OrbyProvider to the root of the app setups all the context and variables that will be used in hooks and function calls to communicate with Orby. 
- Note: If you prefer not to use the Orby React package, you can also create your own functions and classes for calling Orby and setting/managing up context; we're also happy to walk you through the process / code if that's preferred.

[✅] Step 4 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/7): Configure Orby to handle communication with app frontends
- this is perhaps the most involved step of the integration. Generally, we want to inject scripts to into dapps that the user is connected to, and remove it when the user disconnect from the app. 
- Also, we need to use virtual node for all node requests (e.g. `eth_call`) that are routed to the apps from the wallet (some apps do this).
1. make sure the extension has the right permissions. Most extensions have them already so, you probably do not need to do anything but you need  `"activeTab"`, `"scripting"`, and `unlimitedStorage` permissions in the `src/manifest.json` file
2. add webpage.js and core-webpage.js to the manifest's web_accessible_resources
3. add core-webpage-injector.js to the manifest's content_scripts 
4. In your package.json add a command to copy the webpage.min.js to webpage.js, core_webpage.min.js to core-webpage.js and core_webpage_injector.min.js to core-webpage-injector.js. Put this files in the location where they can be build together with other content script files or you can copy them directly into the location of the content script files after build has completed. For Zerion extension, we add them to the `./src/content-script/` before building, and meaning the files are build together with the other content script files.
5. Call the `unifyBalancesOnApps` function your background script with the first argument being the location of the files from step 4 above relative to the root of the build output directory
7. Whenever the app starts get all active app sessions and then call the `useBulkConnectAppSessions` to register them to the background script. Similarly, call the `getVirtualNodeRpcUrlsForSupportedChains` function to get virtual nodes, and add them to your RPC state as the primary way to forward RPC requests from apps the orby. This is necessary because some apps still call wallets for balances, and even generic `eth_calls`.  For the Zerion Extension, this is done in the new `RegisterSessions` component, which is conditionally rendered if the feature flag is set.
9. Whenever a app is connected to the wallet, call the updateConnectedAppSession function
10. Whenever a app is disconnected to the wallet, call the removeConnectedAppSession function 

Testing: At this point, we want to test that the wallet is function as expected.
1. Testing gas abstraction:
- `Control:` Using the Zerion wallet on App store, connect to uniswap with an account that does not have native funds on a chain like BNB Chain, ETH Mainnet, Arbitrum, Base or Optimism.  You should be blocked with a "Insufficient funds for gas" error when you attempt a swap.
- `Orby Enabled:` Now, switch to this Orby enabled Zerion wallet but with the same account. You should not be blocked with a "Insufficient funds for gas" any error when you attempt a swap, and instead you should be able to send the transaction to the wallet for signing.
1. Testing 1-click transactions:
- `Control:` Using the Zerion wallet on App store, connect to uniswap with an account with sufficient funds on a chain like BNB Chain, ETH Mainnet, Arbitrum, Base or Optimism, and attempt a swap with an ERC20 token (e.g. USDC) that has not been approved on uniswap. You should see an "Approve and Swap" CTA when you attempt to swap. Clicking the button sends an ERC20 approval request to the wallet. 
- `Orby Enabled:` Now, switch to this Orby enabled Zerion wallet but with the same account. You should see "Swap" with no approvals needed. Clicking the CTA sends a permit2 typedData to the wallet and not an approval transaction.


[✅] Step 5 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/8): Ping Orby to get  operations for every send transaction from apps
- We add a `useIsOrbyEnabled` hook to check if a chain is orby enabled and if a user has the feature flag enabled
- if orby is enabled, we call the `useGetOperationsToExecuteTransaction` with the transaction data from the user.
- Once we get the operations from Orby, we display them to the user under the details tab
- we also allow the user to pick custom gas tokens from the list of tokens that the user has

Testing: 
- connect to uniswap and initiate a transaction. 
- when the transaction is rendered by the wallet, there should be a way to pick a gas token based on the balances you have on that chain (as shown below)
<img width="357" height="147" alt="Screenshot 2025-07-15 at 01 54 22" src="https://github.com/user-attachments/assets/f00a9e11-9a4c-43ba-9aa4-000346017d15" />

- when you click the details tab, you should see the tokens going in and out of your account
<img width="355" height="237" alt="Screenshot 2025-07-15 at 01 54 56" src="https://github.com/user-attachments/assets/b4cabd5d-d7c6-4055-b047-1fd30dbb50ec" />


- when you click the gas dropdown, you should be able to choose the token of choice for paying for gas
<img width="358" height="480" alt="Screenshot 2025-07-15 at 01 56 33" src="https://github.com/user-attachments/assets/18af3299-cdba-47c0-8073-25fcd6f94aa1" />


- when a custom gas token is chosen, the native token does not show on the input tokens of the details page (e.g. the image below using DAI).
<img width="358" height="267" alt="Screenshot 2025-07-15 at 01 58 36" src="https://github.com/user-attachments/assets/e92a0bef-637c-4d8b-9d42-8c9eb4681575" />


- if you pick a token that is not enough to pay for gas or if there is not enough native tokens for gas, an error is shown
<img width="349" height="215" alt="Screenshot 2025-07-15 at 01 59 50" src="https://github.com/user-attachments/assets/e0aa144e-48fe-4984-84e3-268c30de3126" />


[✅] Step 6 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/9): Ping Orby to get  operations for every send transaction from apps
- We use`useIsOrbyEnabled` hook to check if a chain is orby enabled and if a user has the feature flag enabled
- if orby is enabled, we call the `useGetOperationsToSignTransactionOrSignTypedData` with the typeddata from the user.
- Once we get the operations from Orby, we display them to the user under the details tab
- we also allow the user to pick custom gas tokens from the list of tokens that the user has

Testing: `Follow the same steps as those above but using typeddata instead`. Use Uniswap or Morpho for testing

[❌] Step 7: Verify operations using transaction verification systems such as Blockaid.


[✅] Step 8 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/10): Sign and submit operations
- Create a functions that can be used to sign operations. For signing, we iterate through the operations and sign them one by one. To the user, it seems like they just signed one transaction. We create the `signOperation`, `signTransaction`, and signUserOperation functions in `src/shared/core/orb.ts` file. The functions call the actual wallet signing functions in `src/background/Wallet/Wallet.ts`.
- When the user clicks submit or sign, send operations to Orby using the virtual nodes’ ‘sendOperationSet’ function
- Subscribe to the statuses of these operations from Orby using the `subscribeToOperationStatuses` function
- When the final operation has been successfully submitted, return the result to the user

[👉] Step 9: Fetch and render batched user activity.
- when the orby is enabled, fetch and display batched activuty.
- this means an approve+swap will show as one row



