### PR TITLE
1-click+gas-step 10: add support for Solana gas abstraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,11 @@
         "@ethersproject/hdnode": "^5.7.0",
         "@ethersproject/wallet": "^5.7.0",
         "@noble/ed25519": "^2.2.3",
+<<<<<<< HEAD
         "@orb-labs/orby-react": "^0.0.67",
+=======
+        "@orb-labs/orby-react": "^0.0.65",
+>>>>>>> 1ce9a3df (fetch and show batched operations)
         "@react-spring/web": "^9.7.3",
         "@solana/spl-token": "^0.4.13",
         "@solana/wallet-standard-features": "^1.3.0",
@@ -4498,9 +4502,15 @@
       }
     },
     "node_modules/@orb-labs/orby-core": {
+<<<<<<< HEAD
       "version": "0.0.32",
       "resolved": "https://registry.npmjs.org/@orb-labs/orby-core/-/orby-core-0.0.32.tgz",
       "integrity": "sha512-gr5OKqtY3VFzOBmFMWYNEOBmCJCtaaWc0cPuDcKBXLlgvkth9t8F8S8TK5VZ/nzw7oqeIVw0DUpC4JbYofbUqg==",
+=======
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@orb-labs/orby-core/-/orby-core-0.0.31.tgz",
+      "integrity": "sha512-xULUPWNf+ERkjaDU7uQSSbaxE9CaJqlgoqGJVjGb4bnn1iI8PlyUxL/FU22RJnbSVsjVnAmh8NsC0j+apqZebw==",
+>>>>>>> 1ce9a3df (fetch and show batched operations)
       "dependencies": {
         "@uniswap/sdk-core": "^5.9.0",
         "jsbi": "^3.1.4"
@@ -4532,12 +4542,21 @@
       }
     },
     "node_modules/@orb-labs/orby-react": {
+<<<<<<< HEAD
       "version": "0.0.67",
       "resolved": "https://registry.npmjs.org/@orb-labs/orby-react/-/orby-react-0.0.67.tgz",
       "integrity": "sha512-BX3Wcqil0RAqusGwswM1BJx45xaWumGffq1YpdSQIGEWaM+TGAmRcvZjjb6K/RB5xfGzXfPyNT8hLW5oM2RnVA==",
       "dependencies": {
         "@orb-labs/orby-core-mini": "0.0.11",
         "@orb-labs/orby-viem-extension": "0.0.29",
+=======
+      "version": "0.0.65",
+      "resolved": "https://registry.npmjs.org/@orb-labs/orby-react/-/orby-react-0.0.65.tgz",
+      "integrity": "sha512-wWx2c8D2agS3+xqU7W5vfYmPSbbRmwFgR7WatUZ3fuG7aG6DyErcl+obF2dkxYnjxQnvrRamUVKw8aHtPaas0Q==",
+      "dependencies": {
+        "@orb-labs/orby-core-mini": "0.0.11",
+        "@orb-labs/orby-viem-extension": "0.0.28",
+>>>>>>> 1ce9a3df (fetch and show batched operations)
         "viem": "^2.9.25"
       },
       "peerDependencies": {
@@ -4546,11 +4565,19 @@
       }
     },
     "node_modules/@orb-labs/orby-viem-extension": {
+<<<<<<< HEAD
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@orb-labs/orby-viem-extension/-/orby-viem-extension-0.0.29.tgz",
       "integrity": "sha512-11kq11NIpDakJBEwyG25cVwFSEy3NYOqnUaeve2oQmGRoxEl2/YOaKKrQIqA0t8ZIz3E6EVZm/PpPa//m5grog==",
       "dependencies": {
         "@orb-labs/orby-core": "0.0.32",
+=======
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@orb-labs/orby-viem-extension/-/orby-viem-extension-0.0.28.tgz",
+      "integrity": "sha512-b4jsuq3k5hWzJJ+Ui2J8R801PxXcoAF8zMRGNEk4jDVYjuv9nmDmboBDIIE/cd6GZI2bTeUx1CelSt0Kps46gA==",
+      "dependencies": {
+        "@orb-labs/orby-core": "0.0.31",
+>>>>>>> 1ce9a3df (fetch and show batched operations)
         "ethers": "6"
       },
       "peerDependencies": {
@@ -8388,9 +8415,15 @@
       }
     },
     "node_modules/@scure/bip32/node_modules/@noble/curves": {
+<<<<<<< HEAD
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.4.tgz",
       "integrity": "sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==",
+=======
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.2.tgz",
+      "integrity": "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==",
+>>>>>>> 1ce9a3df (fetch and show batched operations)
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -19218,9 +19251,15 @@
       "license": "MIT"
     },
     "node_modules/ox/node_modules/@noble/curves": {
+<<<<<<< HEAD
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.4.tgz",
       "integrity": "sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==",
+=======
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.2.tgz",
+      "integrity": "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==",
+>>>>>>> 1ce9a3df (fetch and show batched operations)
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -22064,9 +22103,15 @@
       }
     },
     "node_modules/viem": {
+<<<<<<< HEAD
       "version": "2.33.0",
       "resolved": "https://registry.npmjs.org/viem/-/viem-2.33.0.tgz",
       "integrity": "sha512-SxBM3CmeU+LWLlBclV9MPdbuFV8mQEl0NeRc9iyYU4a7Xb5sr5oku3s/bRGTPpEP+1hCAHYpM09/ui3/dQ6EsA==",
+=======
+      "version": "2.31.7",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.31.7.tgz",
+      "integrity": "sha512-mpB8Hp6xK77E/b/yJmpAIQcxcOfpbrwWNItjnXaIA8lxZYt4JS433Pge2gg6Hp3PwyFtaUMh01j5L8EXnLTjQQ==",
+>>>>>>> 1ce9a3df (fetch and show batched operations)
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,7 @@
         "@ethersproject/hdnode": "^5.7.0",
         "@ethersproject/wallet": "^5.7.0",
         "@noble/ed25519": "^2.2.3",
-<<<<<<< HEAD
         "@orb-labs/orby-react": "^0.0.67",
-=======
-        "@orb-labs/orby-react": "^0.0.65",
->>>>>>> 1ce9a3df (fetch and show batched operations)
         "@react-spring/web": "^9.7.3",
         "@solana/spl-token": "^0.4.13",
         "@solana/wallet-standard-features": "^1.3.0",
@@ -4502,15 +4498,9 @@
       }
     },
     "node_modules/@orb-labs/orby-core": {
-<<<<<<< HEAD
       "version": "0.0.32",
       "resolved": "https://registry.npmjs.org/@orb-labs/orby-core/-/orby-core-0.0.32.tgz",
       "integrity": "sha512-gr5OKqtY3VFzOBmFMWYNEOBmCJCtaaWc0cPuDcKBXLlgvkth9t8F8S8TK5VZ/nzw7oqeIVw0DUpC4JbYofbUqg==",
-=======
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/@orb-labs/orby-core/-/orby-core-0.0.31.tgz",
-      "integrity": "sha512-xULUPWNf+ERkjaDU7uQSSbaxE9CaJqlgoqGJVjGb4bnn1iI8PlyUxL/FU22RJnbSVsjVnAmh8NsC0j+apqZebw==",
->>>>>>> 1ce9a3df (fetch and show batched operations)
       "dependencies": {
         "@uniswap/sdk-core": "^5.9.0",
         "jsbi": "^3.1.4"
@@ -4542,21 +4532,12 @@
       }
     },
     "node_modules/@orb-labs/orby-react": {
-<<<<<<< HEAD
       "version": "0.0.67",
       "resolved": "https://registry.npmjs.org/@orb-labs/orby-react/-/orby-react-0.0.67.tgz",
       "integrity": "sha512-BX3Wcqil0RAqusGwswM1BJx45xaWumGffq1YpdSQIGEWaM+TGAmRcvZjjb6K/RB5xfGzXfPyNT8hLW5oM2RnVA==",
       "dependencies": {
         "@orb-labs/orby-core-mini": "0.0.11",
         "@orb-labs/orby-viem-extension": "0.0.29",
-=======
-      "version": "0.0.65",
-      "resolved": "https://registry.npmjs.org/@orb-labs/orby-react/-/orby-react-0.0.65.tgz",
-      "integrity": "sha512-wWx2c8D2agS3+xqU7W5vfYmPSbbRmwFgR7WatUZ3fuG7aG6DyErcl+obF2dkxYnjxQnvrRamUVKw8aHtPaas0Q==",
-      "dependencies": {
-        "@orb-labs/orby-core-mini": "0.0.11",
-        "@orb-labs/orby-viem-extension": "0.0.28",
->>>>>>> 1ce9a3df (fetch and show batched operations)
         "viem": "^2.9.25"
       },
       "peerDependencies": {
@@ -4565,19 +4546,11 @@
       }
     },
     "node_modules/@orb-labs/orby-viem-extension": {
-<<<<<<< HEAD
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@orb-labs/orby-viem-extension/-/orby-viem-extension-0.0.29.tgz",
       "integrity": "sha512-11kq11NIpDakJBEwyG25cVwFSEy3NYOqnUaeve2oQmGRoxEl2/YOaKKrQIqA0t8ZIz3E6EVZm/PpPa//m5grog==",
       "dependencies": {
         "@orb-labs/orby-core": "0.0.32",
-=======
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@orb-labs/orby-viem-extension/-/orby-viem-extension-0.0.28.tgz",
-      "integrity": "sha512-b4jsuq3k5hWzJJ+Ui2J8R801PxXcoAF8zMRGNEk4jDVYjuv9nmDmboBDIIE/cd6GZI2bTeUx1CelSt0Kps46gA==",
-      "dependencies": {
-        "@orb-labs/orby-core": "0.0.31",
->>>>>>> 1ce9a3df (fetch and show batched operations)
         "ethers": "6"
       },
       "peerDependencies": {
@@ -8415,15 +8388,9 @@
       }
     },
     "node_modules/@scure/bip32/node_modules/@noble/curves": {
-<<<<<<< HEAD
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.4.tgz",
       "integrity": "sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==",
-=======
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.2.tgz",
-      "integrity": "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==",
->>>>>>> 1ce9a3df (fetch and show batched operations)
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -19251,15 +19218,9 @@
       "license": "MIT"
     },
     "node_modules/ox/node_modules/@noble/curves": {
-<<<<<<< HEAD
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.4.tgz",
       "integrity": "sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==",
-=======
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.2.tgz",
-      "integrity": "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==",
->>>>>>> 1ce9a3df (fetch and show batched operations)
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -22103,15 +22064,9 @@
       }
     },
     "node_modules/viem": {
-<<<<<<< HEAD
       "version": "2.33.0",
       "resolved": "https://registry.npmjs.org/viem/-/viem-2.33.0.tgz",
       "integrity": "sha512-SxBM3CmeU+LWLlBclV9MPdbuFV8mQEl0NeRc9iyYU4a7Xb5sr5oku3s/bRGTPpEP+1hCAHYpM09/ui3/dQ6EsA==",
-=======
-      "version": "2.31.7",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.31.7.tgz",
-      "integrity": "sha512-mpB8Hp6xK77E/b/yJmpAIQcxcOfpbrwWNItjnXaIA8lxZYt4JS433Pge2gg6Hp3PwyFtaUMh01j5L8EXnLTjQQ==",
->>>>>>> 1ce9a3df (fetch and show batched operations)
       "funding": [
         {
           "type": "github",

--- a/src/background/Wallet/Wallet.ts
+++ b/src/background/Wallet/Wallet.ts
@@ -1363,6 +1363,21 @@ export class Wallet {
     }
   }
 
+  async signSVMTransaction({
+    params,
+  }: WalletMethodParams<{
+    transaction: StringBase64;
+  }>): Promise<SolSignTransactionResult> {
+    this.ensureRecord(this.record);
+    const currentAddress = this.ensureCurrentAddress();
+    const transaction = solFromBase64(params.transaction);
+
+    const keypair = this.getKeypairByAddress(currentAddress);
+    const result = SolanaSigning.signTransaction(transaction, keypair);
+
+    return result;
+  }
+
   async signAndSendTransaction({
     params,
     context,

--- a/src/ui/App/App.tsx
+++ b/src/ui/App/App.tsx
@@ -33,8 +33,14 @@ import {
   useOrby,
 } from '@orb-labs/orby-react';
 import { getPermissionsWithWallets } from 'src/ui/shared/requests/getPermissionsWithWallets';
-import { Account, AccountType, VMType } from '@orb-labs/orby-core';
+import type { VMType } from '@orb-labs/orby-core';
+import {
+  Account,
+  AccountType,
+  validateAndFormatAddress,
+} from '@orb-labs/orby-core';
 import { useIsOneClickTransactionsAndGasAbstractionEnabled } from 'src/shared/core/useIsOneClickTransactionsAndGasAbstractionEnabled';
+import { getWalletVirtualEnvironment } from 'src/shared/core/orb';
 import { Login } from '../pages/Login';
 import { ErrorBoundary } from '../components/ErrorBoundary';
 import {
@@ -552,9 +558,9 @@ export function InnerApp({ initialView, inspect }: AppProps) {
     const accounts = wallet
       ? [
           new Account(
-            wallet?.address?.toLowerCase(),
+            validateAndFormatAddress(wallet?.address),
             AccountType.EOA,
-            VMType.EVM,
+            getWalletVirtualEnvironment(wallet?.address) as VMType,
             undefined
           ),
         ]

--- a/src/ui/pages/SendTransaction/SendTransaction.tsx
+++ b/src/ui/pages/SendTransaction/SendTransaction.tsx
@@ -99,7 +99,11 @@ import ScrollIcon from 'jsx:src/ui/assets/scroll.svg';
 import ArrowDownIcon from 'jsx:src/ui/assets/caret-down-filled.svg';
 import { SiteFaviconImg } from 'src/ui/components/SiteFaviconImg';
 import { NetworkId } from 'src/modules/networks/NetworkId';
-import type { OperationStatus } from '@orb-labs/orby-core';
+import type {
+  OperationSet,
+  OperationStatus,
+  StandardizedBalance,
+} from '@orb-labs/orby-core';
 import { OperationStatusType } from '@orb-labs/orby-core';
 import {
   signUserOperation,
@@ -110,7 +114,7 @@ import _ from 'lodash';
 import type { Hex } from '@noble/ed25519';
 import { useIsOrbyEnabled } from 'src/shared/core/useIsOrbyEnabled';
 import { useOrbyGetOperationsToSignTransactionOrSignTypedData } from 'src/ui/shared/hooks/useOrbyGetOperationsToSignTransactionOrSignTypedData';
-import { useOrby } from '@orb-labs/orby-react';
+import { useGetFungibleTokenPortfolio, useOrby } from '@orb-labs/orby-react';
 import type { PopoverToastHandle } from '../Settings/PopoverToast';
 import { PopoverToast } from '../Settings/PopoverToast';
 import { TransactionConfiguration } from './TransactionConfiguration';
@@ -1064,6 +1068,9 @@ function SolDefaultView({
   origin,
   wallet,
   networks,
+  operationSet,
+  selectedGasToken,
+  selectGasToken,
 }: {
   origin: string;
   addressAction: AnyAddressAction;
@@ -1071,12 +1078,25 @@ function SolDefaultView({
   txInterpretQuery: ReturnType<typeof useInterpretTxBasedOnEligibility>;
   wallet: ExternallyOwnedAccount;
   networks: Networks;
+  operationSet: OperationSet;
+  selectedGasToken: GasTokenInput;
+  selectGasToken: (gasToken?: GasTokenInput) => void;
+  fungibleTokens?: StandardizedBalance[] | undefined;
 }) {
   const originForHref = useMemo(() => prepareForHref(origin), [origin]);
 
   const recipientAddress = addressAction.label?.display_value.wallet_address;
   const actionTransfers = addressAction.content?.transfers;
   const singleAsset = addressAction?.content?.single_asset;
+
+  const chainId = addressAction.transaction.chain
+    ? networks?.getChainId(createChain(addressAction.transaction.chain))
+    : undefined;
+  const isOrbyEnabled = useIsOrbyEnabled(chainId ? BigInt(chainId) : undefined);
+  const { fungibleTokens } = useGetFungibleTokenPortfolio(
+    undefined,
+    chainId && isOrbyEnabled ? BigInt(chainId) : undefined
+  );
 
   const advancedDialogRef = useRef<HTMLDialogElementInterface | null>(null);
 
@@ -1188,6 +1208,9 @@ function SolDefaultView({
             chain={addressAction.transaction.chain}
             networkFee={addressAction.transaction.fee}
             isLoading={txInterpretQuery.isLoading}
+            selectedGasToken={selectedGasToken}
+            selectGasToken={selectGasToken}
+            fungibleTokens={fungibleTokens}
           />
         ) : null}
       </div>
@@ -1208,7 +1231,7 @@ function SolDefaultView({
               transaction={{ solana: rawTransaction }}
               addressAction={addressAction}
               onCopyData={() => toastRef.current?.showToast()}
-              operationSet={undefined}
+              operationSet={operationSet}
             />
           </>
         )}
@@ -1292,9 +1315,19 @@ function SolSendTransaction() {
   invariant(wallet, 'Wallet must be available');
   const { preferences } = usePreferences();
   const sendTxBtnRef = useRef<SendTxBtnHandle | null>(null);
+  const { accountCluster } = useOrby();
+  const isOrbyEnabled = useIsOrbyEnabled(BigInt(101));
+  const [submitOperationSetIsLoading, setSubmitOperationSetIsLoading] =
+    useState(false);
 
   const navigate = useNavigate();
   const next = params.get('next');
+
+  const [selectedGasToken, setSelectedGasToken] = useState<GasTokenInput>({
+    name: 'no gas',
+    standardizedTokenId: undefined,
+    isDefault: true,
+  });
 
   async function handleSentTransaction(res: SignTransactionResult) {
     if (preferences?.enableHoldToSignButton) {
@@ -1326,6 +1359,29 @@ function SolSendTransaction() {
   const localAddressAction = useMemo(
     () => parseSolanaTransaction(wallet.address, solFromBase64(firstTx)),
     [firstTx, wallet.address]
+  );
+
+  const options = useMemo(() => {
+    return new Map([['method', txParams.method]]);
+  }, [txParams.method]);
+
+  const { operationSet, operationSetError, operationSetLoading, virtualNode } =
+    useOrbyGetOperationsToSignTransactionOrSignTypedData(
+      { evm: undefined, solana: firstTx, typedData: undefined },
+      isOrbyEnabled ? wallet : undefined,
+      isOrbyEnabled,
+      selectedGasToken,
+      BigInt(101),
+      options
+    );
+
+  const selectGasToken = useCallback(
+    (gasToken?: GasTokenInput) => {
+      if (gasToken) {
+        setSelectedGasToken(gasToken);
+      }
+    },
+    [setSelectedGasToken]
   );
 
   // TODO: support multiple transactions in simulation
@@ -1390,6 +1446,73 @@ function SolSendTransaction() {
     onSuccess: (tx) => handleSentTransaction(tx),
   });
 
+  const operationStatusesUpdated = useCallback(
+    async (
+      statusSummary: OperationStatusType,
+      finalTransactionStatus?: OperationStatus,
+      _statuses?: OperationStatus[]
+    ) => {
+      if (
+        [OperationStatusType.SUCCESSFUL, OperationStatusType.PENDING].includes(
+          statusSummary
+        )
+      ) {
+        if (txParams.method === 'signAndSendTransaction') {
+          handleSentTransaction({
+            solana: {
+              signature: finalTransactionStatus?.hash as string,
+              publicKey: wallet.address,
+              tx: firstTx,
+            },
+          });
+        } else {
+          sendTransaction();
+        }
+
+        setSubmitOperationSetIsLoading(false);
+      }
+    },
+    [
+      firstTx,
+      handleSentTransaction,
+      sendTransaction,
+      txParams.method,
+      wallet.address,
+    ]
+  );
+
+  const submitTransaction = useCallback(async () => {
+    if (isOrbyEnabled) {
+      if (accountCluster && virtualNode && virtualNode) {
+        setSubmitOperationSetIsLoading(true);
+        const { operationResponses } = await virtualNode.sendOperationSet(
+          accountCluster,
+          operationSet,
+          signTransaction,
+          signUserOperation,
+          signTypedData
+        );
+
+        const ids = operationResponses
+          ?.map((op) => op.id)
+          .filter((id) => !_.isUndefined(id));
+        virtualNode?.subscribeToOperationStatuses(
+          ids,
+          operationStatusesUpdated
+        );
+      }
+    } else {
+      sendTransaction();
+    }
+  }, [
+    accountCluster,
+    operationSet,
+    virtualNode,
+    operationStatusesUpdated,
+    isOrbyEnabled,
+    sendTransaction,
+  ]);
+
   useBackgroundKind(whiteBackgroundKind);
 
   return (
@@ -1409,6 +1532,9 @@ function SolSendTransaction() {
             txInterpretQuery={interpretQuery}
             origin={origin}
             networks={networks}
+            operationSet={operationSet}
+            selectedGasToken={selectedGasToken}
+            selectGasToken={selectGasToken}
           />
         ) : null}
         <Spacer height={16} />
@@ -1419,6 +1545,11 @@ function SolSendTransaction() {
           {sendTransactionMutation.isError ? (
             <UIText kind="body/regular" color="var(--negative-500)">
               {txErrorToMessage(sendTransactionMutation.error)}
+            </UIText>
+          ) : null}
+          {operationSetError ? (
+            <UIText kind="body/regular" color="var(--negative-500)">
+              {operationSetError}
             </UIText>
           ) : null}
           <div
@@ -1436,9 +1567,17 @@ function SolSendTransaction() {
               <SignTransactionButton
                 wallet={wallet}
                 ref={sendTxBtnRef}
-                onClick={() => sendTransaction()}
-                isLoading={sendTransactionMutation.isLoading}
-                disabled={sendTransactionMutation.isLoading}
+                onClick={() => submitTransaction()}
+                isLoading={
+                  sendTransactionMutation.isLoading ||
+                  operationSetLoading ||
+                  submitOperationSetIsLoading
+                }
+                disabled={
+                  sendTransactionMutation.isLoading ||
+                  operationSetLoading ||
+                  submitOperationSetIsLoading
+                }
                 buttonKind="primary"
                 holdToSign={preferences.enableHoldToSignButton}
               />

--- a/src/ui/pages/SendTransaction/TransactionConfiguration/TransactionConfiguration.tsx
+++ b/src/ui/pages/SendTransaction/TransactionConfiguration/TransactionConfiguration.tsx
@@ -36,9 +36,10 @@ import { getFungibleAsset } from 'src/modules/ethereum/transactions/actionAsset'
 import { useGetFungibleTokenPortfolio } from '@orb-labs/orby-react';
 import type { StandardizedBalance } from '@orb-labs/orby-core';
 import { useIsOrbyEnabled } from 'src/shared/core/useIsOrbyEnabled';
+import { useNetworks } from 'src/modules/networks/useNetworks';
 import { NetworkFee } from '../NetworkFee';
 import { NonceLine } from '../NonceLine';
-import type { GasTokenInput } from '../NetworkFee/NetworkFee';
+import { GasTokenSelector, type GasTokenInput } from '../NetworkFee/NetworkFee';
 import { useTransactionFee } from './useTransactionFee';
 
 export function GasbackHint() {
@@ -127,11 +128,17 @@ export function AddressActionNetworkFee({
   networkFee,
   chain,
   isLoading,
+  selectedGasToken,
+  selectGasToken,
+  fungibleTokens,
 }: {
   label?: React.ReactNode;
   networkFee: NonNullable<AddressAction['transaction']['fee']>;
   isLoading: boolean;
   chain: string;
+  selectedGasToken?: GasTokenInput;
+  selectGasToken?: (gasToken?: GasTokenInput) => void;
+  fungibleTokens?: StandardizedBalance[] | undefined;
 }) {
   const { currency } = useCurrency();
   const { asset, fiatCost, assetCost } = useMemo(() => {
@@ -149,6 +156,11 @@ export function AddressActionNetworkFee({
     return { asset, fiatCost, assetCost };
   }, [chain, networkFee.asset, networkFee.quantity]);
 
+  const { networks } = useNetworks();
+  const chainId =
+    chain == 'solana' ? BigInt(101) : networks?.getChainId(createChain(chain));
+  const isOrbyEnabled = useIsOrbyEnabled(chainId ? BigInt(chainId) : undefined);
+
   if (!fiatCost && !assetCost) {
     return null;
   }
@@ -160,6 +172,13 @@ export function AddressActionNetworkFee({
       ) : (
         <UIText kind="small/regular">Network Fee</UIText>
       )}
+      {selectedGasToken && isOrbyEnabled ? (
+        <GasTokenSelector
+          selectedGasToken={selectedGasToken}
+          setSelectedGasToken={selectGasToken}
+          fungibleTokens={fungibleTokens}
+        />
+      ) : null}
 
       <UIText kind="small/accent">
         <HStack gap={8} alignItems="center">

--- a/src/ui/shared/hooks/useOrbyGetOperationsToSignTransactionOrSignTypedData.ts
+++ b/src/ui/shared/hooks/useOrbyGetOperationsToSignTransactionOrSignTypedData.ts
@@ -7,13 +7,15 @@ import { useOperationSetError } from './useOperationSetError';
 
 export function useOrbyGetOperationsToSignTransactionOrSignTypedData(
   transaction: {
-    evm: IncomingTransactionWithChainId | undefined;
-    typedData: string | undefined;
+    evm?: IncomingTransactionWithChainId | undefined;
+    solana?: string | undefined;
+    typedData?: string | undefined;
   },
-  wallet: ExternallyOwnedAccount,
+  wallet: ExternallyOwnedAccount | undefined,
   isOrbyEnabled: boolean | undefined,
   selectedGasToken: GasTokenInput | undefined,
-  chainId: bigint | undefined
+  chainId: bigint | undefined,
+  options?: Map<string, any>
 ) {
   const gasToken = useMemo(() => {
     return selectedGasToken?.standardizedTokenId
@@ -31,6 +33,13 @@ export function useOrbyGetOperationsToSignTransactionOrSignTypedData(
         value: transaction.evm?.value
           ? BigInt(transaction.evm?.value?.toString())
           : undefined,
+        entrypointAccountAddress: wallet?.address as string,
+        chainId,
+        gasToken,
+      };
+    } else if (transaction.solana) {
+      return {
+        data: transaction.solana as string,
         entrypointAccountAddress: wallet?.address as string,
         chainId,
         gasToken,
@@ -59,7 +68,8 @@ export function useOrbyGetOperationsToSignTransactionOrSignTypedData(
     orbyParams?.value,
     orbyParams?.entrypointAccountAddress,
     orbyParams?.chainId,
-    orbyParams.gasToken
+    orbyParams?.gasToken,
+    options
   );
 
   const operationSetError = useOperationSetError(operationSet, isOrbyEnabled);


### PR DESCRIPTION
This PR is step 3 of the steps to add Orby and support 1-click transactions and gas abstraction on the Zerion Chrome Extension. The same steps and similar code can be used on other Chrome Extension wallets.


[✅] Step 0 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/4) : Setup feature flags
- create a remotely configurable feature flag called `one_click_transactions_and_gas_abstraction`
- we will use this feature flag to gate access to the one click transactions and gas abstraction as we do progressive rollout of the feature.
- Zerion uses firebase but you can feature flag system of your choice such as launch darkly

[✅]  Step 1 [(No PR needed)]: Get EVM and SVM testing accounts and set them up. 
- The accounts need to have some funds, though they do not need to be native funds but at least USDC on the chain you want to test on.
- Delete all approvals for EVM accounts using something like revoke cash (https://revoke.cash/)
- Add your accounts to the flag test / development group of the feature created above

[✅]  Step 2 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/5): Get the Orby API keys for an instance and add them to your environment variables.
- The team will give you keys and urls that look like:

        ORBY_PRIVATE_API_KEY=
        ORBY_PUBLIC_API_KEY=
        ORBY_BASE_URL=


- Note: the private and public keys correspond to a particular instance with specific features enabled on that instance. Given that we're working on 1-click transactions and gas abstraction, make sure that only those 2 features are be enabled.

[✅] Step 3 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/6): Add OrbyProvider to the root of your app
- add the @orb-labs/orby-react npm package
- move some components around so that we can add `OrbyProvider` easily
- initialize the OrbyProvider using the current wallet address
- `OrbyProvider`: Adding OrbyProvider to the root of the app setups all the context and variables that will be used in hooks and function calls to communicate with Orby. 
- Note: If you prefer not to use the Orby React package, you can also create your own functions and classes for calling Orby and setting/managing up context; we're also happy to walk you through the process / code if that's preferred.

[✅] Step 4 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/7): Configure Orby to handle communication with app frontends
- this is perhaps the most involved step of the integration. Generally, we want to inject scripts to into dapps that the user is connected to, and remove it when the user disconnect from the app. 
- Also, we need to use virtual node for all node requests (e.g. `eth_call`) that are routed to the apps from the wallet (some apps do this).
1. make sure the extension has the right permissions. Most extensions have them already so, you probably do not need to do anything but you need  `"activeTab"`, `"scripting"`, and `unlimitedStorage` permissions in the `src/manifest.json` file
2. add webpage.js and core-webpage.js to the manifest's web_accessible_resources
3. add core-webpage-injector.js to the manifest's content_scripts 
4. In your package.json add a command to copy the webpage.min.js to webpage.js, core_webpage.min.js to core-webpage.js and core_webpage_injector.min.js to core-webpage-injector.js. Put this files in the location where they can be build together with other content script files or you can copy them directly into the location of the content script files after build has completed. For Zerion extension, we add them to the `./src/content-script/` before building, and meaning the files are build together with the other content script files.
5. Call the `unifyBalancesOnApps` function your background script with the first argument being the location of the files from step 4 above relative to the root of the build output directory
7. Whenever the app starts get all active app sessions and then call the `useBulkConnectAppSessions` to register them to the background script. Similarly, call the `getVirtualNodeRpcUrlsForSupportedChains` function to get virtual nodes, and add them to your RPC state as the primary way to forward RPC requests from apps the orby. This is necessary because some apps still call wallets for balances, and even generic `eth_calls`.  For the Zerion Extension, this is done in the new `RegisterSessions` component, which is conditionally rendered if the feature flag is set.
9. Whenever a app is connected to the wallet, call the updateConnectedAppSession function
10. Whenever a app is disconnected to the wallet, call the removeConnectedAppSession function 

Testing: At this point, we want to test that the wallet is function as expected.
1. Testing gas abstraction:
- `Control:` Using the Zerion wallet on App store, connect to uniswap with an account that does not have native funds on a chain like BNB Chain, ETH Mainnet, Arbitrum, Base or Optimism.  You should be blocked with a "Insufficient funds for gas" error when you attempt a swap.
- `Orby Enabled:` Now, switch to this Orby enabled Zerion wallet but with the same account. You should not be blocked with a "Insufficient funds for gas" any error when you attempt a swap, and instead you should be able to send the transaction to the wallet for signing.
1. Testing 1-click transactions:
- `Control:` Using the Zerion wallet on App store, connect to uniswap with an account with sufficient funds on a chain like BNB Chain, ETH Mainnet, Arbitrum, Base or Optimism, and attempt a swap with an ERC20 token (e.g. USDC) that has not been approved on uniswap. You should see an "Approve and Swap" CTA when you attempt to swap. Clicking the button sends an ERC20 approval request to the wallet. 
- `Orby Enabled:` Now, switch to this Orby enabled Zerion wallet but with the same account. You should see "Swap" with no approvals needed. Clicking the CTA sends a permit2 typedData to the wallet and not an approval transaction.


[✅] Step 5 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/8): Ping Orby to get  operations for every send transaction from apps
- We add a `useIsOrbyEnabled` hook to check if a chain is orby enabled and if a user has the feature flag enabled
- if orby is enabled, we call the `useGetOperationsToExecuteTransaction` with the transaction data from the user.
- Once we get the operations from Orby, we display them to the user under the details tab
- we also allow the user to pick custom gas tokens from the list of tokens that the user has

Testing: 
- connect to uniswap and initiate a transaction. 
- when the transaction is rendered by the wallet, there should be a way to pick a gas token based on the balances you have on that chain (as shown below)
<img width="357" height="147" alt="Screenshot 2025-07-15 at 01 54 22" src="https://github.com/user-attachments/assets/f00a9e11-9a4c-43ba-9aa4-000346017d15" />

- when you click the details tab, you should see the tokens going in and out of your account
<img width="355" height="237" alt="Screenshot 2025-07-15 at 01 54 56" src="https://github.com/user-attachments/assets/b4cabd5d-d7c6-4055-b047-1fd30dbb50ec" />


- when you click the gas dropdown, you should be able to choose the token of choice for paying for gas
<img width="358" height="480" alt="Screenshot 2025-07-15 at 01 56 33" src="https://github.com/user-attachments/assets/18af3299-cdba-47c0-8073-25fcd6f94aa1" />


- when a custom gas token is chosen, the native token does not show on the input tokens of the details page (e.g. the image below using DAI).
<img width="358" height="267" alt="Screenshot 2025-07-15 at 01 58 36" src="https://github.com/user-attachments/assets/e92a0bef-637c-4d8b-9d42-8c9eb4681575" />


- if you pick a token that is not enough to pay for gas or if there is not enough native tokens for gas, an error is shown
<img width="349" height="215" alt="Screenshot 2025-07-15 at 01 59 50" src="https://github.com/user-attachments/assets/e0aa144e-48fe-4984-84e3-268c30de3126" />


[✅] Step 6 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/9): Ping Orby to get  operations for every send transaction from apps
- We use`useIsOrbyEnabled` hook to check if a chain is orby enabled and if a user has the feature flag enabled
- if orby is enabled, we call the `useGetOperationsToSignTransactionOrSignTypedData` with the typeddata from the user.
- Once we get the operations from Orby, we display them to the user under the details tab
- we also allow the user to pick custom gas tokens from the list of tokens that the user has

Testing: `Follow the same steps as those above but using typeddata instead`. Use Uniswap or Morpho for testing

[❌] Step 7: Verify operations using transaction verification systems such as Blockaid.


[✅] Step 8 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/10): Sign and submit operations
- Create a functions that can be used to sign operations. For signing, we iterate through the operations and sign them one by one. To the user, it seems like they just signed one transaction. We create the `signOperation`, `signTransaction`, and signUserOperation functions in `src/shared/core/orb.ts` file. The functions call the actual wallet signing functions in `src/background/Wallet/Wallet.ts`.
- When the user clicks submit or sign, send operations to Orby using the virtual nodes’ ‘sendOperationSet’ function
- Subscribe to the statuses of these operations from Orby using the `subscribeToOperationStatuses` function
- When the final operation has been successfully submitted, return the result to the user

[✅] Step 9: Fetch and render batched user activity.
- when the orby is enabled, fetch and display batched activuty.
- this means an approve+swap will show as one row

[👉] Step 10: Add Support for Solana
- Auto detect the VM from the address before passing the address to the OrbyProvider.
- Use the `useGetOperationsToSignTransactionOrSignTypedData` hook to interact with Orby when `isOrbyEnabled` is true. The encoded SVM `serialized` transaction is passed as a data to the hook along with options to tell the Orby the SVM RPC function we are handling. 
- Add helper functions to `signOperation` to support signing of SVM operations
- Add ability to select gas tokens
- when user clicks confirm, send operations to Orby using the virtual nodes’ ‘sendOperationSet’ function , and then return right value to the app. Note that for signAllTransactions and signTransaction calls, the Orby library does not send the primary operation to Orby. Instead, return the serialized transaction to the app so that the relevant relayer will submit this to the blockchain.









