### PR TITLE
ca-step 0: setup feature flag for enabling chain abstraction

### DIFF
--- a/src/modules/remote-config/plugins/firebase.ts
+++ b/src/modules/remote-config/plugins/firebase.ts
@@ -9,6 +9,7 @@ const defaultConfig: RemoteConfig = {
   extension_wallet_name_flags: {},
   extension_uninstall_link: '',
   one_click_transactions_and_gas_abstraction: true,
+  chain_abstraction_enabled: true,
   extension_loyalty_enabled: true,
   extension_asset_page_enabled: false,
   loyalty_config: {},

--- a/src/modules/remote-config/types.ts
+++ b/src/modules/remote-config/types.ts
@@ -4,6 +4,7 @@ export interface RemoteConfig {
   extension_wallet_name_flags: Record<string, WalletNameFlag[]>;
   extension_uninstall_link: string;
   one_click_transactions_and_gas_abstraction: boolean;
+  chain_abstraction_enabled: boolean;
   extension_loyalty_enabled: boolean;
   extension_asset_page_enabled: boolean;
   fee_comparison_config: Array<{

--- a/src/shared/core/useIsChainAbstractionFeatureFlagEnabled.ts
+++ b/src/shared/core/useIsChainAbstractionFeatureFlagEnabled.ts
@@ -1,0 +1,13 @@
+import { useRemoteConfigValue } from 'src/modules/remote-config/useRemoteConfigValue';
+import { useMemo } from 'react';
+import _ from 'lodash';
+
+export function useIsChainAbstractionFeatureFlagEnabled() {
+  const { data: chainAbstraction } = useRemoteConfigValue(
+    'chain_abstraction_enabled'
+  );
+
+  return useMemo(() => {
+    return (!_.isUndefined(chainAbstraction) && chainAbstraction) || true;
+  }, [chainAbstraction]);
+}

--- a/src/ui/pages/SignTypedData/SignTypedData.tsx
+++ b/src/ui/pages/SignTypedData/SignTypedData.tsx
@@ -659,6 +659,7 @@ function SignTypedDataContent({
     selectedGasToken,
     chainId ? BigInt(chainId) : undefined
   );
+
   const { fungibleTokens } = useGetFungibleTokenPortfolio(
     undefined,
     chainId && isOrbyEnabled ? BigInt(chainId) : undefined

--- a/src/ui/pages/SignTypedData/SignTypedData.tsx
+++ b/src/ui/pages/SignTypedData/SignTypedData.tsx
@@ -659,7 +659,6 @@ function SignTypedDataContent({
     selectedGasToken,
     chainId ? BigInt(chainId) : undefined
   );
-
   const { fungibleTokens } = useGetFungibleTokenPortfolio(
     undefined,
     chainId && isOrbyEnabled ? BigInt(chainId) : undefined


### PR DESCRIPTION
This PR is part of the steps to add Orby chain abstraction on the Zerion Chrome Extension. The same steps and similar code can be used on other Chrome Extension wallets.

[👉] Step 0: Setup feature flags
create a remotely configurable feature flag called `chain_abstraction_enabled`
we will use this feature flag to gate access to the chain abstraction as we do progressive rollout of the feature.
Zerion uses firebase but you can feature flag system of your choice such as launch darkly