### PR TITLE
ca-step 1: update orby config and enable ca at startup

### DIFF
--- a/src/background/Wallet/Wallet.ts
+++ b/src/background/Wallet/Wallet.ts
@@ -1303,11 +1303,12 @@ export class Wallet {
   }
 
   async signTypedData({
-    params: { typedData: rawTypedData },
+    params: { typedData: rawTypedData, address },
   }: WalletMethodParams<{
     typedData: TypedData | string;
+    address: string;
   }>) {
-    const signer = this.getOfflineSigner();
+    const signer = this.getOfflineSignerByAddress(address);
     const signature = signTypedData(rawTypedData, signer);
     return signature;
   }
@@ -1334,7 +1335,6 @@ export class Wallet {
       );
     }
 
-    const chainId = normalizeTransactionChainId(incomingTransaction);
     const transaction = prepareTransaction(incomingTransaction);
     const paymasterEligible = Boolean(transaction.customData?.paymasterParams);
 
@@ -1354,7 +1354,9 @@ export class Wallet {
       }
     } else {
       try {
-        const signer = await this.getSigner(chainId as ChainId);
+        const signer = this.getOfflineSignerByAddress(
+          transaction.from as string
+        );
         const signature = await signer.signTransaction(transaction);
         return signature;
       } catch (error) {
@@ -1367,12 +1369,12 @@ export class Wallet {
     params,
   }: WalletMethodParams<{
     transaction: StringBase64;
+    address: string;
   }>): Promise<SolSignTransactionResult> {
     this.ensureRecord(this.record);
-    const currentAddress = this.ensureCurrentAddress();
+    this.ensureRecord(this.record);
     const transaction = solFromBase64(params.transaction);
-
-    const keypair = this.getKeypairByAddress(currentAddress);
+    const keypair = this.getKeypairByAddress(params.address);
     const result = SolanaSigning.signTransaction(transaction, keypair);
 
     return result;

--- a/src/modules/networks/NetworkSelectValue.ts
+++ b/src/modules/networks/NetworkSelectValue.ts
@@ -1,3 +1,4 @@
 export enum NetworkSelectValue {
   All = 'All',
+  Unified = 'Unified',
 }

--- a/src/shared/core/orb.ts
+++ b/src/shared/core/orb.ts
@@ -47,7 +47,8 @@ export const getWalletVirtualEnvironment = (
 
 export async function signSVMTransaction(
   txRpcUrl: string,
-  data: string
+  data: string,
+  address: string
 ): Promise<string> {
   const connection = new Connection(txRpcUrl);
   const originalTransaction = toTransaction(data);
@@ -61,6 +62,7 @@ export async function signSVMTransaction(
 
   const result = (await walletPort.request('signSVMTransaction', {
     transaction: solToBase64(originalTransaction),
+    address,
   })) as SolSignTransactionResult;
 
   return result.tx;
@@ -94,13 +96,18 @@ async function signEVMTransaction(
     delete parsedData.types['EIP712Domain'];
     return (await walletPort.request('signTypedData', {
       typedData: parsedData,
+      address: operation.from as string,
     })) as string;
   }
 }
 
 async function signOperation(operation: OnchainOperation): Promise<string> {
   if (getWalletVirtualEnvironment(operation.from as string) == VMType.SVM) {
-    return signSVMTransaction(operation.txRpcUrl, operation.data);
+    return signSVMTransaction(
+      operation.txRpcUrl,
+      operation.data,
+      operation.from as string
+    );
   }
 
   return signEVMTransaction(operation);

--- a/src/shared/core/useEnableChainAbstraction.ts
+++ b/src/shared/core/useEnableChainAbstraction.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import _ from 'lodash';
+
+import { NetworkSelectValue } from 'src/modules/networks/NetworkSelectValue';
+import { useEnableChainAbstractionOnAccountCluster } from '@orb-labs/orby-react';
+import { useIsChainAbstractionFeatureFlagEnabled } from './useIsChainAbstractionFeatureFlagEnabled';
+
+export function useEnableChainAbstraction(chain: string) {
+  const chainAbstractionEnabled = useIsChainAbstractionFeatureFlagEnabled();
+
+  const enableChainAbstraction = useMemo(() => {
+    return chain == NetworkSelectValue.Unified && chainAbstractionEnabled;
+  }, [chain, chainAbstractionEnabled]);
+
+  const { isSuccessful } = useEnableChainAbstractionOnAccountCluster(
+    enableChainAbstraction
+  );
+
+  return useMemo(() => {
+    return isSuccessful && enableChainAbstraction;
+  }, [isSuccessful, enableChainAbstraction]);
+}

--- a/src/shared/core/useIsChainAbstractionEnabled.ts
+++ b/src/shared/core/useIsChainAbstractionEnabled.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import _ from 'lodash';
+import { NetworkSelectValue } from 'src/modules/networks/NetworkSelectValue';
+import { useOrby } from '@orb-labs/orby-react';
+import { usePreferences } from 'src/ui/features/preferences';
+
+export function useIsChainAbstractionEnabled() {
+  const { accountCluster } = useOrby();
+  const { preferences } = usePreferences();
+
+  return useMemo(() => {
+    return (
+      accountCluster?.isChainAbstractionEnabled &&
+      preferences?.selectedChain === NetworkSelectValue.Unified
+    );
+  }, [accountCluster?.isChainAbstractionEnabled, preferences?.selectedChain]);
+}

--- a/src/ui/App/App.tsx
+++ b/src/ui/App/App.tsx
@@ -271,7 +271,7 @@ function Views({ initialRoute }: { initialRoute?: string }) {
             }
           />
           <Route
-            path="/asset/:asset_code/:standardizedTokenId"
+            path="/asset/:asset_code"
             element={
               <RequireAuth>
                 <AssetInfo />

--- a/src/ui/App/App.tsx
+++ b/src/ui/App/App.tsx
@@ -41,6 +41,9 @@ import {
 } from '@orb-labs/orby-core';
 import { useIsOneClickTransactionsAndGasAbstractionEnabled } from 'src/shared/core/useIsOneClickTransactionsAndGasAbstractionEnabled';
 import { getWalletVirtualEnvironment } from 'src/shared/core/orb';
+import { useIsChainAbstractionFeatureFlagEnabled } from 'src/shared/core/useIsChainAbstractionFeatureFlagEnabled';
+import { NetworkSelectValue } from 'src/modules/networks/NetworkSelectValue';
+import { useEnableChainAbstraction } from 'src/shared/core/useEnableChainAbstraction';
 import { Login } from '../pages/Login';
 import { ErrorBoundary } from '../components/ErrorBoundary';
 import {
@@ -268,7 +271,7 @@ function Views({ initialRoute }: { initialRoute?: string }) {
             }
           />
           <Route
-            path="/asset/:asset_code"
+            path="/asset/:asset_code/:standardizedTokenId"
             element={
               <RequireAuth>
                 <AssetInfo />
@@ -488,6 +491,8 @@ function GlobalKeyboardShortcuts() {
 }
 
 function RegisterSessions() {
+  useEnableChainAbstraction(NetworkSelectValue.Unified);
+
   const { data: allConnectedSites, isFetching } = useQuery({
     queryKey: ['getPermissionsWithWallets'],
     queryFn: getPermissionsWithWallets,
@@ -542,6 +547,42 @@ export interface AppProps {
   inspect?: { message: string };
 }
 
+function useCurrentWalletGroup() {
+  const { data: currentWallet } = useQuery({
+    queryKey: ['wallet/uiGetCurrentWallet'],
+    queryFn: () => walletPort.request('uiGetCurrentWallet'),
+    useErrorBoundary: true,
+  });
+
+  const {
+    data: walletGroup,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['getWalletGroupByAddress', currentWallet?.address],
+    queryFn: () =>
+      walletPort.request('getWalletGroupByAddress', {
+        address: currentWallet?.address as string,
+      }),
+    enabled: !!currentWallet?.address,
+    useErrorBoundary: false,
+  });
+
+  // Extract all addresses from the wallet group
+  const allAddresses = useMemo(() => {
+    if (!walletGroup) return [];
+    return walletGroup.walletContainer.wallets.map((wallet) => wallet.address);
+  }, [walletGroup]);
+
+  return {
+    currentWallet,
+    walletGroup,
+    allAddresses,
+    isLoading: !currentWallet || isLoading,
+    error,
+  };
+}
+
 export function InnerApp({ initialView, inspect }: AppProps) {
   const isOnboardingMode = urlContext.appMode === 'onboarding';
   const isPageLayout = urlContext.windowLayout === 'page';
@@ -549,22 +590,40 @@ export function InnerApp({ initialView, inspect }: AppProps) {
   const isOnboardingView =
     isOnboardingMode && initialView !== 'handshakeFailure';
 
-  const { data: wallet } = useQuery({
-    queryKey: ['wallet/uiGetCurrentWallet'],
-    queryFn: () => walletPort.request('uiGetCurrentWallet'),
-  });
+  const { currentWallet, allAddresses, isLoading, error } =
+    useCurrentWalletGroup();
+
+  const oneClickTransactionsAndGasAbstractionEnabled =
+    useIsOneClickTransactionsAndGasAbstractionEnabled();
+
+  const chainAbstractionEnabled = useIsChainAbstractionFeatureFlagEnabled();
 
   const orbyConfig = useMemo(() => {
-    const accounts = wallet
-      ? [
-          new Account(
-            validateAndFormatAddress(wallet?.address),
-            AccountType.EOA,
-            getWalletVirtualEnvironment(wallet?.address) as VMType,
-            undefined
-          ),
-        ]
-      : [];
+    let accounts: Account[] = [];
+
+    if (isLoading || error) {
+      accounts = [];
+    } else if (chainAbstractionEnabled) {
+      accounts = allAddresses.map((address) => {
+        return new Account(
+          validateAndFormatAddress(address),
+          AccountType.EOA,
+          getWalletVirtualEnvironment(address) as VMType,
+          undefined
+        );
+      });
+    } else {
+      accounts = currentWallet
+        ? [
+            new Account(
+              validateAndFormatAddress(currentWallet?.address),
+              AccountType.EOA,
+              getWalletVirtualEnvironment(currentWallet?.address) as VMType,
+              undefined
+            ),
+          ]
+        : [];
+    }
 
     return {
       instancePrivateAPIKey: process.env.ORBY_PRIVATE_API_KEY as string,
@@ -573,19 +632,15 @@ export function InnerApp({ initialView, inspect }: AppProps) {
       accounts,
       baseUrl: process.env.ORBY_BASE_URL,
     };
-  }, [wallet]);
-
-  const oneClickTransactionsAndGasAbstractionEnabled =
-    useIsOneClickTransactionsAndGasAbstractionEnabled();
+  }, [isLoading, error, chainAbstractionEnabled, allAddresses, currentWallet]);
 
   return (
     <>
       <OrbyProvider config={orbyConfig}>
         <Router>
           <ErrorBoundary renderError={(error) => <ViewError error={error} />}>
-            {oneClickTransactionsAndGasAbstractionEnabled && (
-              <RegisterSessions />
-            )}
+            {(oneClickTransactionsAndGasAbstractionEnabled ||
+              chainAbstractionEnabled) && <RegisterSessions />}
             <InactivityDetector />
             <SessionResetHandler />
             <TurnstileTokenHandler />

--- a/src/ui/pages/Networks/NetworkSelect/NetworkSelect.tsx
+++ b/src/ui/pages/Networks/NetworkSelect/NetworkSelect.tsx
@@ -10,9 +10,8 @@ import { useAddressParams } from 'src/ui/shared/user-address/useAddressParams';
 import { Button } from 'src/ui/ui-kit/Button';
 import { HStack } from 'src/ui/ui-kit/HStack';
 import AllNetworksIcon from 'jsx:src/ui/assets/all-networks.svg';
-import NetworkIcon from 'jsx:src/ui/assets/network.svg';
 import ArrowDownIcon from 'jsx:src/ui/assets/caret-down-filled.svg';
-import { NetworkIcon as NetworkIconComponent } from 'src/ui/components/NetworkIcon';
+import { NetworkIcon } from 'src/ui/components/NetworkIcon';
 import { noValueDash } from 'src/ui/shared/typography';
 import { createChain } from 'src/modules/networks/Chain';
 import { useNetworks } from 'src/modules/networks/useNetworks';
@@ -69,7 +68,7 @@ export function NetworkSelect({
   function handleDialogOpen() {
     invariant(dialogRef.current, 'Dialog element not found');
     showConfirmDialog(dialogRef.current).then(async (chain) => {
-      if (chain !== 'all' && chain !== NetworkSelectValue.Unified) {
+      if (chain !== 'all') {
         // TODO: should we combine these calls?
         await walletPort.request('uiChainSelected', { chain });
         await walletPort.request('addVisitedEthereumChain', { chain });
@@ -79,10 +78,7 @@ export function NetworkSelect({
     });
   }
 
-  const chain =
-    value === NetworkSelectValue.All || value === NetworkSelectValue.Unified
-      ? null
-      : createChain(value);
+  const chain = value === NetworkSelectValue.All ? null : createChain(value);
   const { networks, isLoading } = useNetworks(
     chain ? [chain.toString()] : undefined
   );
@@ -131,21 +127,13 @@ export function NetworkSelect({
           <HStack gap={8} alignItems="center">
             {!network ||
             value === NetworkSelectValue.All ||
-            value === NetworkSelectValue.Unified ||
             !network.icon_url ? (
-              value === NetworkSelectValue.Unified ? (
-                <NetworkIcon
-                  style={{ width: 24, height: 24 }}
-                  role="presentation"
-                />
-              ) : (
-                <AllNetworksIcon
-                  style={{ width: 24, height: 24 }}
-                  role="presentation"
-                />
-              )
+              <AllNetworksIcon
+                style={{ width: 24, height: 24 }}
+                role="presentation"
+              />
             ) : (
-              <NetworkIconComponent
+              <NetworkIcon
                 size={24}
                 src={network.icon_url}
                 name={network.name}
@@ -155,8 +143,6 @@ export function NetworkSelect({
               <span>
                 {value === NetworkSelectValue.All
                   ? 'All Networks'
-                  : value === NetworkSelectValue.Unified
-                  ? 'Unified'
                   : chain
                   ? networks?.getChainName(chain)
                   : noValueDash}

--- a/src/ui/pages/Networks/NetworkSelect/NetworkSelect.tsx
+++ b/src/ui/pages/Networks/NetworkSelect/NetworkSelect.tsx
@@ -10,8 +10,9 @@ import { useAddressParams } from 'src/ui/shared/user-address/useAddressParams';
 import { Button } from 'src/ui/ui-kit/Button';
 import { HStack } from 'src/ui/ui-kit/HStack';
 import AllNetworksIcon from 'jsx:src/ui/assets/all-networks.svg';
+import NetworkIcon from 'jsx:src/ui/assets/network.svg';
 import ArrowDownIcon from 'jsx:src/ui/assets/caret-down-filled.svg';
-import { NetworkIcon } from 'src/ui/components/NetworkIcon';
+import { NetworkIcon as NetworkIconComponent } from 'src/ui/components/NetworkIcon';
 import { noValueDash } from 'src/ui/shared/typography';
 import { createChain } from 'src/modules/networks/Chain';
 import { useNetworks } from 'src/modules/networks/useNetworks';
@@ -68,7 +69,7 @@ export function NetworkSelect({
   function handleDialogOpen() {
     invariant(dialogRef.current, 'Dialog element not found');
     showConfirmDialog(dialogRef.current).then(async (chain) => {
-      if (chain !== 'all') {
+      if (chain !== 'all' && chain !== NetworkSelectValue.Unified) {
         // TODO: should we combine these calls?
         await walletPort.request('uiChainSelected', { chain });
         await walletPort.request('addVisitedEthereumChain', { chain });
@@ -78,7 +79,10 @@ export function NetworkSelect({
     });
   }
 
-  const chain = value === NetworkSelectValue.All ? null : createChain(value);
+  const chain =
+    value === NetworkSelectValue.All || value === NetworkSelectValue.Unified
+      ? null
+      : createChain(value);
   const { networks, isLoading } = useNetworks(
     chain ? [chain.toString()] : undefined
   );
@@ -127,13 +131,21 @@ export function NetworkSelect({
           <HStack gap={8} alignItems="center">
             {!network ||
             value === NetworkSelectValue.All ||
+            value === NetworkSelectValue.Unified ||
             !network.icon_url ? (
-              <AllNetworksIcon
-                style={{ width: 24, height: 24 }}
-                role="presentation"
-              />
+              value === NetworkSelectValue.Unified ? (
+                <NetworkIcon
+                  style={{ width: 24, height: 24 }}
+                  role="presentation"
+                />
+              ) : (
+                <AllNetworksIcon
+                  style={{ width: 24, height: 24 }}
+                  role="presentation"
+                />
+              )
             ) : (
-              <NetworkIcon
+              <NetworkIconComponent
                 size={24}
                 src={network.icon_url}
                 name={network.name}
@@ -143,6 +155,8 @@ export function NetworkSelect({
               <span>
                 {value === NetworkSelectValue.All
                   ? 'All Networks'
+                  : value === NetworkSelectValue.Unified
+                  ? 'Unified'
                   : chain
                   ? networks?.getChainName(chain)
                   : noValueDash}


### PR DESCRIPTION
This PR is part of the steps to add Orby chain abstraction on the Zerion Chrome Extension. The same steps and similar code can be used on other Chrome Extension wallets.

[✅]  Step 0 PR (https://github.com/orb-labs/zerion-wallet-extension/pull/15): Setup feature flags
- create a remotely configurable feature flag called chain_abstraction_enabled. we will use this feature flag to gate access to the chain abstraction as we do progressive rollout of the feature.
Zerion uses firebase but you can feature flag system of your choice such as launch darkly

[👉] Step 1: Update Update OrbyConfig to include the other VM accounts and update signing of operations
- get all the addresses and accounts that you want to include together. For this Zerion example, we want to include all the accounts that are part of the same wallet group. That means account that are derived from the same mnemonic are grouped together regardless of the VM that they are part of. Specifically, Zerion supports both EVM and SVM, so we will have chain abstraction and unified balances on the SVM and EVM
- update the signing operations to fetch a signer based on the address that the operation is from
- use the feature flag from step 0 to turn on chain abstraction on Orby. When the feature flag is on, turn on chain abstraction on Orby for the user

Testing: At this point, we should have chain abstraction enabled for the accounts we set in the OrbyConfig
- import an account to Zerion using a mnemonic
- Connect to uniswap. You should see unified balances on the app across SVM and EVM. Also, you should be able to perform a transaction using the unified balances
- Connect jupiter (e.g. https://jup.ag/swap?sell=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&buy=So11111111111111111111111111111111111111112) you should also see your balances unified across EVM and SVM. Also, you should be able to perform a transaction using the unified balances

