### PR TITLE
ca-step 2: add unified network and make it the default

### DIFF
--- a/src/background/Wallet/WalletRecord.ts
+++ b/src/background/Wallet/WalletRecord.ts
@@ -30,6 +30,7 @@ import { encodeForMasking } from 'src/shared/wallet/encode-locally';
 import { isSolanaAddress } from 'src/modules/solana/shared';
 import type { AtLeastOneOf } from 'src/shared/type-utils/OneOf';
 import type { BlockchainType } from 'src/shared/wallet/classifiers';
+import { NetworkSelectValue } from 'src/modules/networks/NetworkSelectValue';
 import type { Credentials, SessionCredentials } from '../account/Credentials';
 import { emitter } from '../events';
 import type {
@@ -299,7 +300,9 @@ export class WalletRecordModel {
         },
         transactions: [],
         permissions: {},
-        publicPreferences: {},
+        publicPreferences: {
+          selectedChain: NetworkSelectValue.Unified,
+        },
         activityRecord: {},
         feed: { completedAbilities: [], dismissedAbilities: [] },
       };
@@ -845,6 +848,7 @@ export class WalletRecordModel {
     const defaults: Required<WalletRecord['publicPreferences']> = {
       showNetworkSwitchShortcut: true,
       overviewChain: '',
+      selectedChain: NetworkSelectValue.Unified,
       configurableNonce: false,
       invitationBannerDismissed: false,
       recentAddresses: [],

--- a/src/background/Wallet/model/types.ts
+++ b/src/background/Wallet/model/types.ts
@@ -40,6 +40,11 @@ interface PublicPreferences {
   /** @deprecated */
   overviewChain?: string;
   /**
+   * The user's selected network chain for portfolio filtering
+   * Defaults to "unified" when not set
+   */
+  selectedChain?: string;
+  /**
    * Allow to configure nonce before signing transactions
    */
   configurableNonce?: boolean;

--- a/src/ui/components/NetworkSelectDialog/NetworkSelectDialog.tsx
+++ b/src/ui/components/NetworkSelectDialog/NetworkSelectDialog.tsx
@@ -25,6 +25,7 @@ import { SearchInput } from 'src/ui/ui-kit/Input/SearchInput';
 import { DialogCloseButton } from 'src/ui/ui-kit/ModalDialogs/DialogTitle/DialogCloseButton';
 import { NetworkSelectValue } from 'src/modules/networks/NetworkSelectValue';
 import AllNetworksIcon from 'jsx:src/ui/assets/all-networks.svg';
+import NetworkIcon from 'jsx:src/ui/assets/network.svg';
 import { usePreferences } from 'src/ui/features/preferences/usePreferences';
 import { VirtualizedSurfaceList } from 'src/ui/ui-kit/SurfaceList/VirtualizedSurfaceList';
 import { useNativeBalance } from 'src/ui/shared/requests/useNativeBalance';
@@ -35,8 +36,9 @@ import type { BlockchainType } from 'src/shared/wallet/classifiers';
 import EcosystemEthereumIcon from 'jsx:src/ui/assets/ecosystem-ethereum.svg';
 import EcosystemSolanaIcon from 'jsx:src/ui/assets/ecosystem-solana.svg';
 import { isMatchForEcosystem } from 'src/shared/wallet/shared';
+import { useIsChainAbstractionFeatureFlagEnabled } from 'src/shared/core/useIsChainAbstractionFeatureFlagEnabled';
 import { DelayedRender } from '../DelayedRender';
-import { NetworkIcon } from '../NetworkIcon';
+import { NetworkIcon as NetworkIconComponent } from '../NetworkIcon';
 import { PageBottom } from '../PageBottom';
 import { PageColumn } from '../PageColumn';
 import { ViewLoading } from '../ViewLoading';
@@ -84,8 +86,12 @@ function NetworkItem({
 }) {
   const preferChainDistribution =
     value === NetworkSelectValue.All ||
+    value === NetworkSelectValue.Unified ||
     value in (chainDistribution?.chains || {});
-  const chain = value === NetworkSelectValue.All ? null : createChain(value);
+  const chain =
+    value === NetworkSelectValue.All || value === NetworkSelectValue.Unified
+      ? null
+      : createChain(value);
   const { currency } = useCurrency();
 
   return (
@@ -126,7 +132,12 @@ function NetworkItem({
             ecosystem
           ) ? null : preferChainDistribution ? (
             <ChainValue
-              chain={chain || NetworkSelectValue.All}
+              chain={
+                chain ||
+                (value === NetworkSelectValue.Unified
+                  ? NetworkSelectValue.Unified
+                  : NetworkSelectValue.All)
+              }
               chainDistribution={chainDistribution}
               currency={currency}
             />
@@ -157,6 +168,16 @@ function NetworkList({
   showAllNetworksOption?: boolean;
 }) {
   const { singleAddress } = useAddressParams();
+  const isChainAbstractionEnabled = useIsChainAbstractionFeatureFlagEnabled();
+  const indexOffset = useMemo(() => {
+    if (!showAllNetworksOption) {
+      return 1;
+    } else if (!isChainAbstractionEnabled) {
+      return 1;
+    }
+    return 2;
+  }, [isChainAbstractionEnabled, showAllNetworksOption]);
+
   const items = [
     title
       ? {
@@ -174,6 +195,29 @@ function NetworkList({
           ),
         }
       : null,
+    // Add Unified item above All Networks
+    isChainAbstractionEnabled
+      ? {
+          key: NetworkSelectValue.Unified,
+          isInteractive: true,
+          pad: false,
+          component: (
+            <NetworkItem
+              index={previousListLength}
+              name="Unified"
+              value={NetworkSelectValue.Unified}
+              selected={value === NetworkSelectValue.Unified}
+              chainDistribution={chainDistribution}
+              icon={
+                <NetworkIcon
+                  style={{ width: 24, height: 24 }}
+                  role="presentation"
+                />
+              }
+            />
+          ),
+        }
+      : null,
     showAllNetworksOption
       ? {
           key: NetworkSelectValue.All,
@@ -181,7 +225,7 @@ function NetworkList({
           pad: false,
           component: (
             <NetworkItem
-              index={previousListLength}
+              index={previousListLength + (isChainAbstractionEnabled ? 1 : 0)}
               name="All Networks"
               value={NetworkSelectValue.All}
               selected={value === NetworkSelectValue.All}
@@ -204,11 +248,11 @@ function NetworkList({
         pad: false,
         component: (
           <NetworkItem
-            index={previousListLength + index + (showAllNetworksOption ? 1 : 0)}
+            index={previousListLength + index + indexOffset}
             name={networks.getChainName(chain)}
             value={network.id}
             icon={
-              <NetworkIcon
+              <NetworkIconComponent
                 size={24}
                 src={network.icon_url}
                 name={network.name}

--- a/src/ui/pages/History/History.tsx
+++ b/src/ui/pages/History/History.tsx
@@ -201,9 +201,11 @@ export function HistoryList({
   const showNetworkSelector = addressType === 'evm';
   const { preferences } = usePreferences();
 
-  const chainValue = selectedChain || dappChain || NetworkSelectValue.All;
+  const chainValue = selectedChain || dappChain || NetworkSelectValue.Unified;
   const chain =
-    chainValue && chainValue !== NetworkSelectValue.All
+    chainValue &&
+    chainValue !== NetworkSelectValue.All &&
+    chainValue !== NetworkSelectValue.Unified
       ? createChain(chainValue)
       : null;
 

--- a/src/ui/pages/Networks/NetworkSelect/NetworkSelect.tsx
+++ b/src/ui/pages/Networks/NetworkSelect/NetworkSelect.tsx
@@ -10,8 +10,9 @@ import { useAddressParams } from 'src/ui/shared/user-address/useAddressParams';
 import { Button } from 'src/ui/ui-kit/Button';
 import { HStack } from 'src/ui/ui-kit/HStack';
 import AllNetworksIcon from 'jsx:src/ui/assets/all-networks.svg';
+import NetworkIcon from 'jsx:src/ui/assets/network.svg';
 import ArrowDownIcon from 'jsx:src/ui/assets/caret-down-filled.svg';
-import { NetworkIcon } from 'src/ui/components/NetworkIcon';
+import { NetworkIcon as NetworkIconComponent } from 'src/ui/components/NetworkIcon';
 import { noValueDash } from 'src/ui/shared/typography';
 import { createChain } from 'src/modules/networks/Chain';
 import { useNetworks } from 'src/modules/networks/useNetworks';
@@ -68,7 +69,7 @@ export function NetworkSelect({
   function handleDialogOpen() {
     invariant(dialogRef.current, 'Dialog element not found');
     showConfirmDialog(dialogRef.current).then(async (chain) => {
-      if (chain !== 'all') {
+      if (chain !== 'all' && chain !== NetworkSelectValue.Unified) {
         // TODO: should we combine these calls?
         await walletPort.request('uiChainSelected', { chain });
         await walletPort.request('addVisitedEthereumChain', { chain });
@@ -78,7 +79,10 @@ export function NetworkSelect({
     });
   }
 
-  const chain = value === NetworkSelectValue.All ? null : createChain(value);
+  const chain =
+    value === NetworkSelectValue.All || value === NetworkSelectValue.Unified
+      ? null
+      : createChain(value);
   const { networks, isLoading } = useNetworks(
     chain ? [chain.toString()] : undefined
   );
@@ -127,13 +131,21 @@ export function NetworkSelect({
           <HStack gap={8} alignItems="center">
             {!network ||
             value === NetworkSelectValue.All ||
+            value === NetworkSelectValue.Unified ||
             !network.icon_url ? (
-              <AllNetworksIcon
-                style={{ width: 24, height: 24 }}
-                role="presentation"
-              />
+              value === NetworkSelectValue.Unified ? (
+                <NetworkIcon
+                  style={{ width: 24, height: 24 }}
+                  role="presentation"
+                />
+              ) : (
+                <AllNetworksIcon
+                  style={{ width: 24, height: 24 }}
+                  role="presentation"
+                />
+              )
             ) : (
-              <NetworkIcon
+              <NetworkIconComponent
                 size={24}
                 src={network.icon_url}
                 name={network.name}
@@ -143,6 +155,8 @@ export function NetworkSelect({
               <span>
                 {value === NetworkSelectValue.All
                   ? 'All Networks'
+                  : value === NetworkSelectValue.Unified
+                  ? 'Unified'
                   : chain
                   ? networks?.getChainName(chain)
                   : noValueDash}

--- a/src/ui/pages/Overview/Banners/Banners.tsx
+++ b/src/ui/pages/Overview/Banners/Banners.tsx
@@ -11,6 +11,7 @@ import { InviteFriendsBanner } from 'src/ui/features/referral-program/InviteFrie
 import { Spacer } from 'src/ui/ui-kit/Spacer';
 import { ENABLE_DNA_BANNERS } from 'src/ui/DNA/components/DnaBanners';
 import { FEATURE_LOYALTY_FLOW, FEATURE_SOLANA } from 'src/env/config';
+import { NetworkSelectValue } from 'src/modules/networks/NetworkSelectValue';
 import { SolanaBanner } from './SolanaBanner';
 
 function DnaBanners({ address }: { address: string }) {
@@ -33,7 +34,12 @@ function DnaBanners({ address }: { address: string }) {
         <>
           <MintBanner
             address={address}
-            onDismiss={() => setPreferences({ mintDnaBannerDismissed: true })}
+            onDismiss={() =>
+              setPreferences({
+                mintDnaBannerDismissed: true,
+                selectedChain: NetworkSelectValue.Unified,
+              })
+            }
           />
           <Spacer height={24} />
         </>
@@ -43,7 +49,10 @@ function DnaBanners({ address }: { address: string }) {
           <UpgradeBanner
             address={address}
             onDismiss={() =>
-              setPreferences({ upgradeDnaBannerDismissed: true })
+              setPreferences({
+                upgradeDnaBannerDismissed: true,
+                selectedChain: NetworkSelectValue.Unified,
+              })
             }
           />
           <Spacer height={24} />
@@ -76,7 +85,12 @@ export function Banners({ address }: { address: string }) {
       {solanaBannerVisible ? (
         <>
           <SolanaBanner
-            onDismiss={() => setPreferences({ solanaBannerDismissed: true })}
+            onDismiss={() =>
+              setPreferences({
+                solanaBannerDismissed: true,
+                selectedChain: NetworkSelectValue.Unified,
+              })
+            }
           />
           <Spacer height={24} />
         </>
@@ -84,7 +98,10 @@ export function Banners({ address }: { address: string }) {
         <>
           <InviteFriendsBanner
             onDismiss={() =>
-              setPreferences({ invitationBannerDismissed: true })
+              setPreferences({
+                invitationBannerDismissed: true,
+                selectedChain: NetworkSelectValue.Unified,
+              })
             }
           />
           <Spacer height={24} />

--- a/src/ui/pages/Overview/ConnectionHeader/ConnectionHeader.tsx
+++ b/src/ui/pages/Overview/ConnectionHeader/ConnectionHeader.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import SettingsIcon from 'jsx:src/ui/assets/filters.svg';
 import { invariant } from 'src/shared/invariant';
@@ -15,10 +21,11 @@ import { useAddressParams } from 'src/ui/shared/user-address/useAddressParams';
 import { VStack } from 'src/ui/ui-kit/VStack';
 import { UIText } from 'src/ui/ui-kit/UIText';
 import { walletPort } from 'src/ui/shared/channels';
-import { requestChainForOrigin } from 'src/ui/shared/requests/requestChainForOrigin';
 import { NetworkIcon } from 'src/ui/components/NetworkIcon';
+import NetworkIconSvg from 'jsx:src/ui/assets/network.svg';
 import ArrowDownIcon from 'jsx:src/ui/assets/caret-down-filled.svg';
 import { createChain } from 'src/modules/networks/Chain';
+import { NetworkSelectValue } from 'src/modules/networks/NetworkSelectValue';
 import { INTERNAL_ORIGIN } from 'src/background/constants';
 import {
   useMainnetNetwork,
@@ -31,6 +38,7 @@ import { isEthereumAddress } from 'src/shared/isEthereumAddress';
 import { getAddressType } from 'src/shared/wallet/classifiers';
 import { isMatchForEcosystem } from 'src/shared/wallet/shared';
 import { Networks } from 'src/modules/networks/Networks';
+import { useEnableChainAbstraction } from 'src/shared/core/useEnableChainAbstraction';
 import { ConnectedSiteDialog } from '../../ConnectedSites/ConnectedSite';
 import { NetworkSelect } from '../../Networks/NetworkSelect';
 import { isConnectableDapp } from '../../ConnectedSites/shared/isConnectableDapp';
@@ -47,14 +55,18 @@ function NetworksDisclosureButton({
 }) {
   const { networks, isLoading } = useNetworks();
   const { preferences } = usePreferences();
-  const selectedNetwork = networks?.getNetworkByName(createChain(value));
+  const selectedNetwork =
+    value === NetworkSelectValue.Unified
+      ? null
+      : networks?.getNetworkByName(createChain(value));
 
   const { data: mainnetNetwork } = useMainnetNetwork({
     chain: value,
     enabled:
       Boolean(preferences?.testnetMode?.on) && !isLoading && !selectedNetwork,
   });
-  const chain = createChain(value);
+  const chain =
+    value === NetworkSelectValue.Unified ? null : createChain(value);
   const network = selectedNetwork || mainnetNetwork;
 
   if (isLoading) {
@@ -77,7 +89,9 @@ function NetworksDisclosureButton({
       className="parent-hover"
     >
       <HStack gap={8} alignItems="center">
-        {network ? (
+        {value === NetworkSelectValue.Unified ? (
+          <NetworkIconSvg style={{ width: 24, height: 24 }} />
+        ) : network ? (
           <NetworkIcon size={24} src={network.icon_url} name={network.name} />
         ) : null}
         <span
@@ -94,7 +108,9 @@ function NetworksDisclosureButton({
               textOverflow: 'ellipsis',
             }}
           >
-            {network?.name || capitalize(String(chain))}
+            {value === NetworkSelectValue.Unified
+              ? 'Unified'
+              : network?.name || capitalize(String(chain))}
           </span>
           <ArrowDownIcon
             className="content-hover"
@@ -127,17 +143,12 @@ export function ConnectionHeader() {
   const { singleAddressNormalized: address } = useAddressParams();
   const { data: isConnected } = useIsConnectedToActiveTab(address);
 
-  const { data: siteChain, ...chainQuery } = useQuery({
-    queryKey: ['requestChainForOrigin', activeTabOrigin, address],
-    queryFn: async () => {
-      if (activeTabOrigin) {
-        return requestChainForOrigin(activeTabOrigin, getAddressType(address));
-      }
-    },
-    enabled: Boolean(activeTabOrigin),
-    useErrorBoundary: true,
-    suspense: false,
-  });
+  const { preferences, setPreferences } = usePreferences();
+  const selectedChain = useMemo(() => {
+    return preferences?.selectedChain || NetworkSelectValue.Unified;
+  }, [preferences?.selectedChain]);
+
+  useEnableChainAbstraction(selectedChain);
 
   const switchChainMutation = useMutation({
     mutationFn: ({ chain, origin }: { chain: string; origin: string }) => {
@@ -156,7 +167,9 @@ export function ConnectionHeader() {
       }
     },
     useErrorBoundary: true,
-    onSuccess: () => chainQuery.refetch(),
+    onSuccess: (_, { chain }) => {
+      setPreferences({ selectedChain: chain || NetworkSelectValue.Unified });
+    },
   });
 
   const isConnectableSite = tabData?.url
@@ -270,11 +283,13 @@ export function ConnectionHeader() {
                     Connected
                   </UIText>
                 </VStack>
-                {siteChain ? (
+                {preferences?.selectedChain ? (
                   <NetworkSelect
                     standard={getAddressType(address)}
                     showEcosystemHint={true}
-                    value={siteChain.toString()}
+                    value={
+                      preferences?.selectedChain || NetworkSelectValue.Unified
+                    }
                     filterPredicate={(network) =>
                       isMatchForEcosystem(
                         address,

--- a/src/ui/pages/Overview/NonFungibleTokens/NonFungibleTokens.tsx
+++ b/src/ui/pages/Overview/NonFungibleTokens/NonFungibleTokens.tsx
@@ -192,13 +192,14 @@ export function NonFungibleTokens({
     currency,
   });
   const { value: nftTotalValue } = useNftsTotalValue(params);
-  const chainValue = selectedChain || dappChain || NetworkSelectValue.All;
+  const chainValue = selectedChain || dappChain || NetworkSelectValue.Unified;
   const addressType = getAddressType(address);
   const showNetworkSelector = addressType === 'evm';
 
   // Derive a canonical chain to check nft support if current chain value is "all"
   const referenceChain =
-    chainValue === NetworkSelectValue.All
+    chainValue === NetworkSelectValue.All ||
+    chainValue === NetworkSelectValue.Unified
       ? isSolanaAddress(singleAddressNormalized)
         ? NetworkId.Solana
         : NetworkId.Ethereum
@@ -216,7 +217,9 @@ export function NonFungibleTokens({
     {
       ...params,
       chains:
-        isSupportedByBackend && chainValue !== NetworkSelectValue.All
+        isSupportedByBackend &&
+        chainValue !== NetworkSelectValue.All &&
+        chainValue !== NetworkSelectValue.Unified
           ? [chainValue]
           : undefined,
       currency,
@@ -236,7 +239,8 @@ export function NonFungibleTokens({
   }
 
   const nftChainValue =
-    chainValue === NetworkSelectValue.All
+    chainValue === NetworkSelectValue.All ||
+    chainValue === NetworkSelectValue.Unified
       ? nftTotalValue
       : nftDistribution?.floor_price[chainValue];
 

--- a/src/ui/pages/Overview/Overview.tsx
+++ b/src/ui/pages/Overview/Overview.tsx
@@ -5,7 +5,7 @@ import RewardsIcon from 'jsx:src/ui/assets/rewards.svg';
 import ReadonlyIcon from 'jsx:src/ui/assets/visible.svg';
 import React, { useEffect, useMemo, useRef } from 'react';
 import { RenderArea } from 'react-area';
-import { Route, Routes, useLocation, useSearchParams } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { FEATURE_LOYALTY_FLOW } from 'src/env/config';
 import { useCurrency } from 'src/modules/currency/useCurrency';
 import { updateAddressDnaInfo } from 'src/modules/dna-service/dna.client';
@@ -69,6 +69,8 @@ import { UnstyledButton } from 'src/ui/ui-kit/UnstyledButton';
 import { UnstyledLink } from 'src/ui/ui-kit/UnstyledLink';
 import { VStack } from 'src/ui/ui-kit/VStack';
 import { getAddressType } from 'src/shared/wallet/classifiers';
+import { NetworkSelectValue } from 'src/modules/networks/NetworkSelectValue';
+import { useEnableChainAbstraction } from 'src/shared/core/useEnableChainAbstraction';
 import { ViewSuspense } from '../../components/ViewSuspense';
 import { WalletAvatar } from '../../components/WalletAvatar';
 import { Feed } from '../Feed';
@@ -353,7 +355,15 @@ function OverviewComponent() {
   useBodyStyle(
     useMemo(() => ({ ['--background' as string]: 'var(--z-index-0)' }), [])
   );
+  const { preferences, setPreferences } = usePreferences();
   const { currency } = useCurrency();
+
+  const selectedChain = useMemo(() => {
+    return preferences?.selectedChain || NetworkSelectValue.Unified;
+  }, [preferences?.selectedChain]);
+
+  useEnableChainAbstraction(selectedChain);
+
   const location = useLocation();
   const {
     singleAddress: address,
@@ -368,16 +378,12 @@ function OverviewComponent() {
   });
   const isReadonlyGroup =
     walletGroup && isReadonlyContainer(walletGroup.walletContainer);
-  const [searchParams, setSearchParams] = useSearchParams();
-  const selectedChain = searchParams.get('chain') || null;
+
   const setSelectedChain = useEvent((value: string | null) => {
-    // setSearchParams is not a stable reference: https://github.com/remix-run/react-router/issues/9304
-    setSearchParams(value ? [['chain', value]] : '');
+    setPreferences({ selectedChain: value || NetworkSelectValue.Unified });
   });
+
   const addressType = getAddressType(address);
-  useEffect(() => {
-    setSelectedChain(null);
-  }, [addressType, setSelectedChain]);
   const { data, isLoading: isLoadingPortfolio } = useWalletPortfolio(
     { addresses: [params.address], currency },
     { source: useHttpClientSource() },
@@ -432,7 +438,9 @@ function OverviewComponent() {
     if (singleAddressNormalized) {
       updateAddressDnaInfo(singleAddressNormalized);
     }
-  }, [singleAddressNormalized]);
+
+    setSelectedChain(null);
+  }, [singleAddressNormalized, setSelectedChain]);
 
   const { data: isConnected } = useIsConnectedToActiveTab(
     singleAddressNormalized
@@ -450,7 +458,6 @@ function OverviewComponent() {
     </CenteredFillViewportView>
   );
 
-  const { preferences, setPreferences } = usePreferences();
   const isTestnetMode = Boolean(preferences?.testnetMode?.on);
   const isTestnetModeOnFirstRender = useRef<boolean | null>(isTestnetMode);
   useEffect(() => {
@@ -475,7 +482,10 @@ function OverviewComponent() {
                 <UnstyledButton
                   className="underline hover:no-underline"
                   onClick={() => {
-                    setPreferences({ testnetMode: null });
+                    setPreferences({
+                      testnetMode: null,
+                      selectedChain: NetworkSelectValue.Unified,
+                    });
                   }}
                 >
                   Turn off Testnet Mode
@@ -484,7 +494,10 @@ function OverviewComponent() {
                 <UnstyledButton
                   className="underline hover:no-underline"
                   onClick={() => {
-                    setPreferences({ testnetMode: { on: true } });
+                    setPreferences({
+                      testnetMode: { on: true },
+                      selectedChain: NetworkSelectValue.Unified,
+                    });
                   }}
                 >
                   Turn on Testnet Mode

--- a/src/ui/pages/Overview/Positions/NetworkBalance.tsx
+++ b/src/ui/pages/Overview/Positions/NetworkBalance.tsx
@@ -21,11 +21,10 @@ import { NBSP } from 'src/ui/shared/typography';
 import type { BlockchainType } from 'src/shared/wallet/classifiers';
 import { Networks } from 'src/modules/networks/Networks';
 import { NetworkId } from 'src/modules/networks/NetworkId';
+import { useIsChainAbstractionFeatureFlagEnabled } from 'src/shared/core/useIsChainAbstractionFeatureFlagEnabled';
 import { NetworkSelect } from '../../Networks/NetworkSelect';
 import { getTabScrollContentHeight, offsetValues } from '../getTabsOffset';
 import * as styles from './styles.module.css';
-
-const allNetworksString = 'All Networks';
 
 function DisclosureButton({
   value,
@@ -43,7 +42,7 @@ function DisclosureButton({
   const { networks, isLoading } = useNetworks();
   const { preferences } = usePreferences();
   const selectedNetwork =
-    value === NetworkSelectValue.All
+    value === NetworkSelectValue.All || value === NetworkSelectValue.Unified
       ? null
       : networks?.getNetworkByName(createChain(value));
 
@@ -53,14 +52,17 @@ function DisclosureButton({
       Boolean(preferences?.testnetMode?.on) &&
       !isLoading &&
       !selectedNetwork &&
-      value !== NetworkSelectValue.All,
+      value !== NetworkSelectValue.All &&
+      value !== NetworkSelectValue.Unified,
   });
 
   const network = selectedNetwork || mainnetNetwork;
 
   const selectedNetworkName =
     value === NetworkSelectValue.All
-      ? allNetworksString
+      ? 'All Networks'
+      : value === NetworkSelectValue.Unified
+      ? 'Unified'
       : network?.name || value;
 
   return (
@@ -147,16 +149,36 @@ export function NetworkBalance({
 
   const chain = temporary_solanaDisabledSelector
     ? NetworkId.Solana
-    : selectedChain || dappChain || NetworkSelectValue.All;
+    : selectedChain || dappChain || NetworkSelectValue.Unified;
 
-  const isClearableFilter = Boolean(selectedChain);
-  const showHelperButton =
-    !temporary_solanaDisabledSelector && Boolean(selectedChain || dappChain);
+  const chainAbstractionEnabled = useIsChainAbstractionFeatureFlagEnabled();
+
+  const showHelperButton = useMemo(() => {
+    if (chainAbstractionEnabled) {
+      return selectedChain !== NetworkSelectValue.Unified;
+    }
+
+    return !temporary_solanaDisabledSelector && Boolean(selectedChain);
+  }, [
+    chainAbstractionEnabled,
+    temporary_solanaDisabledSelector,
+    selectedChain,
+  ]);
+
   const showAllNetworksHelperButton =
-    (!dappChain && selectedChain !== NetworkSelectValue.All) ||
-    (dappChain && (!selectedChain || selectedChain === dappChain));
+    selectedChain !== NetworkSelectValue.Unified &&
+    selectedChain !== NetworkSelectValue.All;
 
   const hasValue = totalValue != null;
+
+  const isChainAbstractionEnabled = useIsChainAbstractionFeatureFlagEnabled();
+
+  const name = useMemo(() => {
+    if (isChainAbstractionEnabled) {
+      return NetworkSelectValue.Unified;
+    }
+    return 'All Networks';
+  }, [isChainAbstractionEnabled]);
 
   useEffect(() => {
     const handleScroll = () =>
@@ -227,9 +249,7 @@ export function NetworkBalance({
           showAllNetworksOption={showAllNetworksOption}
           value={chain}
           standard={standard}
-          onChange={(selectedValue) =>
-            onChange(selectedValue === dappChain ? null : selectedValue)
-          }
+          onChange={(selectedValue) => onChange(selectedValue)}
           renderButton={({ value, openDialog }) => (
             <DisclosureButton
               value={value}
@@ -245,7 +265,7 @@ export function NetworkBalance({
           <Button
             kind="text-primary"
             onClick={() =>
-              onChange(isClearableFilter ? null : NetworkSelectValue.All)
+              onChange(showAllNetworksHelperButton ? name : dappChain)
             }
             style={{
               ['--button-text' as string]: 'var(--primary)',
@@ -254,9 +274,7 @@ export function NetworkBalance({
               textOverflow: 'ellipsis',
             }}
           >
-            {showAllNetworksHelperButton
-              ? allNetworksString
-              : dappNetwork?.name}
+            {showAllNetworksHelperButton ? name : dappNetwork?.name}
           </Button>
         ) : null}
       </HStack>

--- a/src/ui/pages/Overview/Positions/Positions.tsx
+++ b/src/ui/pages/Overview/Positions/Positions.tsx
@@ -152,6 +152,7 @@ function AddressPositionItem({
   const { networks } = useNetworks();
   const network = networks?.getNetworkByName(createChain(position.chain));
   const chain = createChain(position.chain);
+  const { preferences } = usePreferences();
 
   const relativeChange = (position.asset.price?.relative_change_24h || 0) / 100;
   const absoluteChange = Math.abs(
@@ -214,7 +215,8 @@ function AddressPositionItem({
                 alignItems: 'center',
               }}
             >
-              {position.chain !== NetworkId.Ethereum ? (
+              {position.chain !== NetworkId.Ethereum &&
+              preferences?.selectedChain !== NetworkSelectValue.Unified ? (
                 <NetworkIcon
                   size={16}
                   name={network?.name || null}
@@ -689,7 +691,7 @@ function MultiChainPositions({
   );
   const positions = data?.data;
 
-  const chainValue = selectedChain || dappChain || NetworkSelectValue.All;
+  const chainValue = selectedChain || dappChain || NetworkSelectValue.Unified;
 
   const items = useMemo(
     () =>
@@ -697,6 +699,7 @@ function MultiChainPositions({
         (position) =>
           (position.type === 'asset' ? position.is_displayable : true) &&
           (chainValue === NetworkSelectValue.All ||
+            chainValue === NetworkSelectValue.Unified ||
             position.chain === chainValue)
       ),
     [chainValue, positions]
@@ -712,7 +715,8 @@ function MultiChainPositions({
   }
 
   const chainTotalValue =
-    chainValue === NetworkSelectValue.All
+    chainValue === NetworkSelectValue.All ||
+    chainValue === NetworkSelectValue.Unified
       ? portfolioDecomposition?.totalValue
       : portfolioDecomposition?.positionsChainsDistribution[chainValue];
 
@@ -843,12 +847,18 @@ export function Positions({
     { enabled: ready && !addrIsSolana }
   );
   const walletPortfolio = data?.data;
-  const chainValue = selectedChain || dappChain || NetworkSelectValue.All;
+  const chainValue = selectedChain || dappChain || NetworkSelectValue.Unified;
   const chain =
-    chainValue === NetworkSelectValue.All ? null : createChain(chainValue);
+    chainValue === NetworkSelectValue.All ||
+    chainValue === NetworkSelectValue.Unified
+      ? null
+      : createChain(chainValue);
   const positionChains = useMemo(() => {
     const chainsSet = new Set(Object.keys(walletPortfolio?.chains || {}));
-    if (chainValue !== NetworkSelectValue.All) {
+    if (
+      chainValue !== NetworkSelectValue.All &&
+      chainValue !== NetworkSelectValue.Unified
+    ) {
       chainsSet.add(chainValue);
     }
     return Array.from(chainsSet);
@@ -870,7 +880,9 @@ export function Positions({
       </CenteredFillViewportView>
     );
   }
-  const moveGasPositionToFront = chainValue !== NetworkSelectValue.All;
+  const moveGasPositionToFront =
+    chainValue !== NetworkSelectValue.All &&
+    chainValue !== NetworkSelectValue.Unified;
   const OVERRIDE_POSITIONS_SUPPORT = addrIsSolana; // todo: remove when backend updates NetworkConfig for Solana
   const isSupportedByBackend =
     chain == null
@@ -898,7 +910,8 @@ export function Positions({
   );
 
   const renderEmptyViewForNetwork = () =>
-    chainValue === NetworkSelectValue.All ? (
+    chainValue === NetworkSelectValue.All ||
+    chainValue === NetworkSelectValue.Unified ? (
       <DelayedRender delay={50}>
         <VStack gap={8}>
           <div style={{ paddingInline: 16 }}>

--- a/src/ui/pages/SendForm/SendForm.tsx
+++ b/src/ui/pages/SendForm/SendForm.tsx
@@ -69,6 +69,7 @@ import {
 import { useIsOrbyEnabled } from 'src/shared/core/useIsOrbyEnabled';
 import _ from 'lodash';
 import { useOrbyGetOperationsToSignTransactionOrSignTypedData } from 'src/ui/shared/hooks/useOrbyGetOperationsToSignTransactionOrSignTypedData';
+import { NetworkSelectValue } from 'src/modules/networks/NetworkSelectValue';
 import { TransactionConfiguration } from '../SendTransaction/TransactionConfiguration';
 import { NetworkSelect } from '../Networks/NetworkSelect';
 import { txErrorToMessage } from '../SendTransaction/shared/transactionErrorToMessage';
@@ -295,6 +296,7 @@ function SendFormComponent() {
       });
       if (preferences) {
         setPreferences({
+          selectedChain: NetworkSelectValue.Unified,
           recentAddresses: updateRecentAddresses(
             to,
             preferences.recentAddresses

--- a/src/ui/shared/channels.mock.ts
+++ b/src/ui/shared/channels.mock.ts
@@ -4,6 +4,7 @@ import {
   ETHEREUM_CHAIN_SOURCES,
   networksStore,
 } from 'src/modules/networks/networks-store.client.mock';
+import { NetworkSelectValue } from 'src/modules/networks/NetworkSelectValue';
 import { normalizeAddress } from 'src/shared/normalizeAddress';
 import type { BareWallet } from 'src/shared/types/BareWallet';
 import type { GlobalPreferences } from 'src/shared/types/GlobalPreferences';
@@ -51,6 +52,7 @@ const mockRecord: WalletRecord = {
     overviewChain: '',
     configurableNonce: true,
     invitationBannerDismissed: false,
+    selectedChain: NetworkSelectValue.Unified,
   },
   permissions: mockedPermissions,
   transactions: [],

--- a/src/ui/shared/requests/PortfolioValue/ChainValue/ChainValue.tsx
+++ b/src/ui/shared/requests/PortfolioValue/ChainValue/ChainValue.tsx
@@ -14,12 +14,12 @@ export function ChainValue({
   chain,
   currency,
 }: {
-  chain: Chain | NetworkSelectValue.All;
+  chain: Chain | NetworkSelectValue.All | NetworkSelectValue.Unified;
   chainDistribution: ChainDistribution | null;
   currency: string;
 }) {
   const value =
-    chain === NetworkSelectValue.All
+    chain === NetworkSelectValue.All || chain === NetworkSelectValue.Unified
       ? chainDistribution?.totalValue
       : chainDistribution?.positionsChainsDistribution[chain.toString()];
 


### PR DESCRIPTION
This PR is part of the steps to add Orby chain abstraction on the Zerion Chrome Extension. The same steps and similar code can be used on other Chrome Extension wallets.

[✅] Step 0 PR(https://github.com/orb-labs/zerion-wallet-extension/pull/15): Setup feature flags
- create a remotely configurable feature flag called chain_abstraction_enabled. we will use this feature flag to gate access to the chain abstraction as we do progressive rollout of the feature.
Zerion uses firebase but you can feature flag system of your choice such as launch darkly

[✅] Step 1 PR(https://github.com/orb-labs/zerion-wallet-extension/pull/16): Update Update OrbyConfig to include the other VM accounts and update signing of operations
- get all the addresses and accounts that you want to include together. For this Zerion example, we want to include all the accounts that are part of the same wallet group. That means account that are derived from the same mnemonic are grouped together regardless of the VM that they are part of. Specifically, Zerion supports both EVM and SVM, so we will have chain abstraction and unified balances on the SVM and EVM
- update the signing operations to fetch a signer based on the address that the operation is from
- use the feature flag from step 0 to turn on chain abstraction on Orby. When the feature flag is on, turn on chain abstraction on Orby for the user

Testing: At this point, we should have chain abstraction enabled for the accounts we set in the OrbyConfig
- import an account to Zerion using a mnemonic
- Connect to uniswap. You should see unified balances on the app across SVM and EVM. Also, you should be able to perform a transaction using the unified balances
- Connect jupiter (e.g. https://jup.ag/swap?sell=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&buy=So11111111111111111111111111111111111111112) you should also see your balances unified across EVM and SVM. Also, you should be able to perform a transaction using the unified balances

[👉] Step 2: Introduce unified network and make it default
We want to separate the chain that the connected app is on from the chain / view that the user is on. To do that, we introduce the notion of `selectedChain` in the app preferences. This value can be updated/changed by the user and it is set to `NetworkSelectValue.Unified` by default. When an app ask for a chain switch, we update the `selectedChain` iff its current value is not `NetworkSelectValue.Unified`. 

Not, we do not seek to remove all the chains and allow user to be able to select `All Networks` and separate networks because we want to allow the option for users to see a particular view they want. Here is now the wallet looks with these changes:
<img width="369" height="470" alt="Screenshot 2025-07-22 at 11 57 52" src="https://github.com/user-attachments/assets/daae60ac-f96a-43da-96d3-f58d7fe3eb12" />

<img width="355" height="101" alt="Screenshot 2025-07-22 at 11 58 09" src="https://github.com/user-attachments/assets/74252f84-d7ab-4485-9264-ae9ff885d82f" />

<img width="367" height="97" alt="Screenshot 2025-07-22 at 11 58 27" src="https://github.com/user-attachments/assets/493cf6c7-e485-461c-9424-105416043c1d" />
