### PR TITLE
ca-step 3: displaying a unified portfolio view

### DIFF
--- a/src/modules/networks/networks-fallback.ts
+++ b/src/modules/networks/networks-fallback.ts
@@ -756,4 +756,62 @@ export const networksFallbackInfo: NetworkConfig[] = [
     supports_sponsored_transactions: false,
     supports_simulations: true,
   },
+  {
+    id: 'solana',
+    name: 'Solana',
+    icon_url: 'https://chain-icons.s3.amazonaws.com/solana.png',
+    is_testnet: false,
+    standard: 'solana',
+    specification: {
+      solana: {},
+    },
+    native_asset: {
+      id: '11111111111111111111111111111111',
+      address: '11111111111111111111111111111111',
+      name: 'Solana',
+      symbol: 'SOL',
+      decimals: 9,
+    },
+    wrapped_native_asset: null,
+    rpc_url_internal: 'https://rpc.zerion.io/v1/solana',
+    rpc_url_public: ['https://api.mainnet-beta.solana.com'],
+    explorer_name: 'Solana Explorer',
+    explorer_token_url: 'https://explorer.solana.com/address/{ADDRESS}',
+    explorer_address_url: 'https://explorer.solana.com/address/{ADDRESS}',
+    explorer_tx_url: 'https://explorer.solana.com/tx/{HASH}',
+    explorer_home_url: 'https://explorer.solana.com',
+    explorer_urls: ['https://explorer.solana.com'],
+    supports_sending: true,
+    supports_trading: true,
+    supports_bridging: false,
+    supports_actions: true,
+    supports_positions: true,
+    supports_nft_positions: true,
+    supports_sponsored_transactions: false,
+    supports_simulations: true,
+  },
 ];
+
+/**
+ * Finds a network configuration by chain ID from networksFallbackInfo
+ * @param chainId - The chain ID as a string or number
+ * @returns The network configuration or undefined if not found
+ */
+export function findNetworkByChainId(
+  chainId: string | number
+): NetworkConfig | undefined {
+  const chainIdStr = chainId.toString();
+
+  return networksFallbackInfo.find((network) => {
+    // Check for EIP-155 networks
+    if (network.specification?.eip155?.id.toString() === chainIdStr) {
+      return true;
+    }
+    // Check for Solana networks
+    return (
+      network.specification?.solana &&
+      network.id === 'solana' &&
+      chainIdStr === '101'
+    );
+  });
+}

--- a/src/shared/converters/calculateStandardizedQuantity.ts
+++ b/src/shared/converters/calculateStandardizedQuantity.ts
@@ -1,0 +1,22 @@
+import { BigNumber } from 'bignumber.js';
+import type { StandardizedBalance } from '@orb-labs/orby-core';
+
+interface CalculateStandardizedQuantityParams {
+  standardizedBalance: StandardizedBalance;
+  assetImplementationDecimals?: number;
+}
+
+/**
+ * Calculates the quantity for a position from StandardizedBalance data
+ * @param params - Object containing StandardizedBalance and optional decimals
+ * @returns Formatted quantity string
+ */
+export function calculateStandardizedQuantity({
+  standardizedBalance,
+  assetImplementationDecimals = 0,
+}: CalculateStandardizedQuantityParams): string {
+  return new BigNumber(standardizedBalance.total.toRawAmount().toString())
+    .shiftedBy(assetImplementationDecimals)
+    .shiftedBy(0 - standardizedBalance?.total?.currency?.decimals)
+    .toString();
+}

--- a/src/shared/converters/convertFungibleTokensToAddressPositions.ts
+++ b/src/shared/converters/convertFungibleTokensToAddressPositions.ts
@@ -1,0 +1,112 @@
+import { ethers } from 'ethers';
+import type { AddressPosition } from 'defi-sdk';
+import type { StandardizedBalance } from '@orb-labs/orby-core';
+import { NetworkSelectValue } from 'src/modules/networks/NetworkSelectValue';
+import { findNetworkByChainId } from 'src/modules/networks/networks-fallback';
+import type { Chain } from 'src/modules/networks/Chain';
+import { createTokenImplementations } from './createTokenImplementations';
+import { calculateStandardizedQuantity } from './calculateStandardizedQuantity';
+
+/**
+ * Gets the Zerion asset ID for native tokens based on chain ID
+ * @param chainId - The chain ID as a bigint
+ * @returns The asset ID string
+ */
+function getNativeTokenAssetId(chainId: bigint): string {
+  const chainIdStr = chainId.toString();
+
+  // Find the network config using the helper function
+  const networkConfig = findNetworkByChainId(chainIdStr);
+
+  if (networkConfig?.native_asset?.id) {
+    return networkConfig.native_asset.id;
+  }
+
+  // Fallback for unknown chains
+  return `chain-${chainId}`;
+}
+
+/**
+ * Converts fungibleTokens (StandardizedBalance[]) into AddressPosition[] format
+ * to match the structure expected by the positions components
+ *
+ * @param fungibleTokens - Array of StandardizedBalance objects from Orby
+ * @returns Array of AddressPosition objects compatible with existing UI components
+ */
+export function convertFungibleTokensToAddressPositions(
+  fungibleTokens: StandardizedBalance[] | undefined,
+  entryPointChain?: Chain,
+  entryPointChainId?: bigint
+): AddressPosition[] {
+  if (!fungibleTokens || fungibleTokens?.length === 0) {
+    return [];
+  }
+
+  return fungibleTokens.map((standardizedBalance) => {
+    // Based on GasTokenSelector usage, we access token.total.currency and token.total.amount
+    const currencyInfo = standardizedBalance.total.currency;
+    const quantity = calculateStandardizedQuantity({
+      standardizedBalance,
+      assetImplementationDecimals: 0,
+    });
+
+    // Find the token balance with the biggest value or the one matching entryPointChainId
+    const firstTokenBalance = (() => {
+      if (!standardizedBalance.tokenBalancesOnChains?.length) {
+        return standardizedBalance.tokenBalancesOnChains?.[0];
+      }
+
+      // First, try to find the one matching entryPointChainId
+      const matchingChain = standardizedBalance.tokenBalancesOnChains.find(
+        (tokenBalance) => tokenBalance.token.chainId === entryPointChainId
+      );
+
+      if (matchingChain) {
+        return matchingChain;
+      }
+
+      // If no match found, find the one with the biggest value
+      const sortedByValue = [...standardizedBalance.tokenBalancesOnChains].sort(
+        (a, b) => Number(b.toExact()) - Number(a.toExact())
+      );
+
+      return sortedByValue[0];
+    })();
+
+    // Handle native tokens (zero address) and other tokens
+    const isNativeToken =
+      firstTokenBalance?.token.address === ethers.ZeroAddress;
+    const assetId = isNativeToken
+      ? getNativeTokenAssetId(firstTokenBalance?.token.chainId ?? BigInt(1))
+      : firstTokenBalance?.token.address ?? '';
+
+    return {
+      standardizedTokenId: standardizedBalance.standardizedTokenId,
+      id: standardizedBalance.standardizedTokenId,
+      chain: entryPointChain?.value ?? NetworkSelectValue.Unified,
+      value: standardizedBalance?.totalValueInFiat?.toExact() || null,
+      apy: null,
+      included_in_chart: false,
+      name: 'Asset',
+      quantity,
+      protocol: null,
+      dapp: null,
+      type: 'asset' as const,
+      is_displayable: true,
+      asset: {
+        is_displayable: true,
+        type: null,
+        name: currencyInfo.name,
+        symbol: currencyInfo.symbol,
+        id: assetId,
+        asset_code: firstTokenBalance?.token?.address ?? '',
+        decimals: currencyInfo.decimals,
+        icon_url: currencyInfo.logoUrl || null,
+        is_verified: true,
+        price: null, // Price information not available in StandardizedBalance
+        implementations: createTokenImplementations(standardizedBalance),
+      },
+      parent_id: null,
+    };
+  });
+}

--- a/src/shared/converters/createChainAddressKey.ts
+++ b/src/shared/converters/createChainAddressKey.ts
@@ -1,0 +1,14 @@
+import { validateAndFormatAddress } from '@orb-labs/orby-core';
+
+/**
+ * Creates a key string from chainId and address for mapping purposes
+ * @param chainId - The chain ID (can be number, string, or bigint)
+ * @param address - The token address
+ * @returns Formatted key string in format "{chainId}+{address}"
+ */
+export function createChainAddressKey(
+  chainId: number | string | bigint,
+  address: string
+): string {
+  return `${BigInt(chainId).toString()}+${validateAndFormatAddress(address)}`;
+}

--- a/src/shared/converters/createChainAddressToStandardizedBalanceMap.ts
+++ b/src/shared/converters/createChainAddressToStandardizedBalanceMap.ts
@@ -1,0 +1,32 @@
+import { type StandardizedBalance } from '@orb-labs/orby-core';
+import { createChainAddressKey } from './createChainAddressKey';
+
+/**
+ * Creates a map of {chainId}+{address} to StandardizedBalance from fungible tokens
+ * @param fungibleTokens - Array of StandardizedBalance objects from Orby
+ * @returns Map where key is "{chainId}+{address}" and value is the corresponding StandardizedBalance
+ */
+export function createChainAddressToStandardizedBalanceMap(
+  fungibleTokens: StandardizedBalance[] | undefined
+): Map<string, StandardizedBalance> {
+  const map = new Map<string, StandardizedBalance>();
+
+  if (!fungibleTokens || fungibleTokens.length === 0) {
+    return map;
+  }
+
+  for (const standardizedBalance of fungibleTokens) {
+    if (!standardizedBalance.tokenBalancesOnChains?.length) {
+      continue;
+    }
+
+    for (const tokenBalance of standardizedBalance.tokenBalancesOnChains) {
+      const chainId = tokenBalance.token.chainId.toString();
+      const address = tokenBalance.token.address;
+      const key = createChainAddressKey(chainId, address);
+      map.set(key, standardizedBalance);
+    }
+  }
+
+  return map;
+}

--- a/src/shared/converters/createTokenImplementations.ts
+++ b/src/shared/converters/createTokenImplementations.ts
@@ -1,0 +1,31 @@
+import { findNetworkByChainId } from 'src/modules/networks/networks-fallback';
+import type { StandardizedBalance } from '@orb-labs/orby-core';
+
+/**
+ * Creates token implementations object from StandardizedBalance tokenBalancesOnChains
+ * @param standardizedBalance - StandardizedBalance object from Orby
+ * @returns Object with chain names as keys and token implementation details as values
+ */
+export function createTokenImplementations(
+  standardizedBalance: StandardizedBalance
+): Record<string, { address: string; decimals: number }> {
+  return standardizedBalance.tokenBalancesOnChains.reduce(
+    (acc, tokenBalance) => {
+      // Find the network config to get the chain name used in Zerion app
+      const networkConfig = findNetworkByChainId(
+        tokenBalance.token.chainId.toString()
+      );
+      const chainName =
+        networkConfig?.id || tokenBalance.token.chainId.toString();
+
+      return {
+        ...acc,
+        [chainName]: {
+          address: tokenBalance.token.address,
+          decimals: tokenBalance.token.decimals,
+        },
+      };
+    },
+    {}
+  );
+}

--- a/src/shared/converters/index.ts
+++ b/src/shared/converters/index.ts
@@ -1,0 +1,7 @@
+export { convertFungibleTokensToAddressPositions } from './convertFungibleTokensToAddressPositions';
+export { createChainAddressToStandardizedBalanceMap } from './createChainAddressToStandardizedBalanceMap';
+export { createTokenImplementations } from './createTokenImplementations';
+export { processUnifiedPositions } from './processUnifiedPositions';
+export { calculateStandardizedQuantity } from './calculateStandardizedQuantity';
+export { createChainAddressKey } from './createChainAddressKey';
+export { normalizeTokenAddress } from './normalizeTokenAddress';

--- a/src/shared/converters/normalizeTokenAddress.ts
+++ b/src/shared/converters/normalizeTokenAddress.ts
@@ -1,0 +1,21 @@
+import { ethers } from 'ethers';
+
+/**
+ * Normalizes token addresses, handling native tokens and special cases
+ * @param address - The token address to normalize
+ * @returns Normalized address (ZeroAddress for native tokens, original for others)
+ */
+export function normalizeTokenAddress(
+  address: string | null | undefined
+): string {
+  // Handle Solana native token and null/undefined cases
+  if (
+    ['11111111111111111111111111111111', null, undefined].includes(
+      address as string
+    )
+  ) {
+    return ethers.ZeroAddress;
+  }
+
+  return address as string;
+}

--- a/src/shared/converters/processUnifiedPositions.ts
+++ b/src/shared/converters/processUnifiedPositions.ts
@@ -1,0 +1,78 @@
+import { createChain } from 'src/modules/networks/Chain';
+import type { StandardizedBalance } from '@orb-labs/orby-core';
+import type { Networks } from 'src/modules/networks/Networks';
+import type { AddressPositionWithStandardizedTokenId } from '../types/AddressPositionWithStandardizedTokenId';
+import { createTokenImplementations } from './createTokenImplementations';
+import { calculateStandardizedQuantity } from './calculateStandardizedQuantity';
+import { createChainAddressKey } from './createChainAddressKey';
+import { normalizeTokenAddress } from './normalizeTokenAddress';
+
+interface ProcessUnifiedPositionsParams {
+  positions: AddressPositionWithStandardizedTokenId[] | undefined;
+  chainAddressToStandardizedBalanceMap: Map<string, StandardizedBalance>;
+  networks?: Networks | undefined;
+}
+
+/**
+ * Processes positions data by filtering and transforming using StandardizedBalance data
+ * @param params - Object containing positions data and mapping
+ * @returns Filtered and processed positions array
+ */
+export function processUnifiedPositions({
+  positions,
+  chainAddressToStandardizedBalanceMap,
+  networks,
+}: ProcessUnifiedPositionsParams):
+  | AddressPositionWithStandardizedTokenId[]
+  | undefined {
+  const seenStandardizedTokenIds = new Set<string>();
+
+  return positions?.filter((position) => {
+    const asset = position.asset;
+    const chainName = position.chain;
+
+    const assetImplementation = asset?.implementations?.[chainName];
+    const address = normalizeTokenAddress(assetImplementation?.address);
+
+    const chain = createChain(chainName);
+    const chainId =
+      chain?.value == 'solana'
+        ? 101
+        : chain?.value && networks
+        ? networks.getChainId(chain)
+        : null;
+
+    if (!chainId) {
+      return false;
+    }
+
+    const key = createChainAddressKey(chainId, address as string);
+    const standardizedBalance = chainAddressToStandardizedBalanceMap.get(key);
+
+    // Create a unique key for this position
+    const positionKey = standardizedBalance?.standardizedTokenId as string;
+
+    // If we've already seen this standardized token ID, skip it
+    if (seenStandardizedTokenIds.has(positionKey)) {
+      return false;
+    }
+
+    // Mark this standardized token ID as seen
+    seenStandardizedTokenIds.add(positionKey);
+
+    // Update position with standardized balance data
+    if (standardizedBalance) {
+      position.standardizedTokenId = standardizedBalance.standardizedTokenId;
+      position.quantity = calculateStandardizedQuantity({
+        standardizedBalance,
+        assetImplementationDecimals: assetImplementation?.decimals,
+      });
+
+      position.value = standardizedBalance?.totalValueInFiat?.toExact() || null;
+      position.asset.implementations =
+        createTokenImplementations(standardizedBalance);
+    }
+
+    return true;
+  });
+}

--- a/src/shared/types/AddressPositionWithStandardizedTokenId.ts
+++ b/src/shared/types/AddressPositionWithStandardizedTokenId.ts
@@ -1,0 +1,6 @@
+import type { AddressPosition } from 'defi-sdk';
+
+export interface AddressPositionWithStandardizedTokenId
+  extends AddressPosition {
+  standardizedTokenId?: string;
+}

--- a/src/ui/App/App.tsx
+++ b/src/ui/App/App.tsx
@@ -271,7 +271,7 @@ function Views({ initialRoute }: { initialRoute?: string }) {
             }
           />
           <Route
-            path="/asset/:asset_code"
+            path="/asset/:asset_code/:standardizedTokenId"
             element={
               <RequireAuth>
                 <AssetInfo />

--- a/src/ui/pages/AssetInfo/AssetInfo.tsx
+++ b/src/ui/pages/AssetInfo/AssetInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { NavigationType, useNavigationType, useParams } from 'react-router-dom';
 import { useCurrency } from 'src/modules/currency/useCurrency';
 import { invariant } from 'src/shared/invariant';
@@ -35,6 +35,10 @@ import { useCopyToClipboard } from 'src/ui/shared/useCopyToClipboard';
 import { UnstyledButton } from 'src/ui/ui-kit/UnstyledButton';
 import type { PopoverToastHandle } from 'src/ui/pages/Settings/PopoverToast';
 import { PopoverToast } from 'src/ui/pages/Settings/PopoverToast';
+import { useGetFungibleTokenBalances } from '@orb-labs/orby-react';
+import type { StandardizedBalance } from '@orb-labs/orby-core';
+import type { WalletAssetDetails } from 'src/modules/zerion-api/requests/wallet-get-asset-details';
+import { findNetworkByChainId } from 'src/modules/networks/networks-fallback';
 import { AssetHistory } from './AssetHistory';
 import { AssetAddressStats } from './AssetAddressDetails';
 import { AssetGlobalStats } from './AssetGlobalStats';
@@ -46,6 +50,72 @@ import {
 } from './AssetHeader';
 import { AssetDescription } from './AssetDescription';
 import * as styles from './styles.module.css';
+
+/**
+ * Converts tokensInfo (StandardizedBalance) into walletAssetDetails format,
+ * using walletData to fill missing data from tokensInfo
+ */
+function convertTokensInfoToWalletAssetDetails(
+  tokensInfo: StandardizedBalance | undefined,
+  walletData: WalletAssetDetails | undefined
+): WalletAssetDetails | undefined {
+  if (!tokensInfo) {
+    return walletData;
+  }
+
+  if (!walletData) {
+    // If no walletData, create a minimal structure from tokensInfo
+    const totalValue = Number(tokensInfo.totalValueInFiat?.toExact()) || 0;
+    const totalConvertedQuantity = Number(
+      tokensInfo.total.toRawAmount().toString()
+    );
+
+    return {
+      chainsDistribution: null,
+      wallets: [],
+      apps: null,
+      totalValue,
+      totalConvertedQuantity,
+    };
+  }
+
+  // Use walletData as base and enhance with tokensInfo data
+  const enhancedWalletData: WalletAssetDetails = {
+    ...walletData,
+    // Update total values with tokensInfo data if available
+    totalValue:
+      Number(tokensInfo.totalValueInFiat?.toExact()) || walletData.totalValue,
+    totalConvertedQuantity:
+      Number(tokensInfo.total.toRawAmount().toString()) ||
+      walletData.totalConvertedQuantity,
+  };
+
+  enhancedWalletData.chainsDistribution = tokensInfo.tokenBalancesOnChains
+    .map((tokenBalance) => {
+      const chainId = tokenBalance.token.chainId.toString();
+
+      // Find the network config using the helper function
+      const networkConfig = findNetworkByChainId(chainId);
+
+      return {
+        chain: {
+          id: networkConfig?.id || chainId,
+          name: networkConfig?.name || `Chain ${chainId}`,
+          iconUrl: networkConfig?.icon_url || '',
+          testnet: networkConfig?.is_testnet || false,
+        },
+        value: Number(tokenBalance.toExact()) || 0,
+        percentageAllocation:
+          tokensInfo.total.toRawAmount() === BigInt(0)
+            ? 0
+            : (100 * Number(tokenBalance.toExact())) /
+              Number(tokensInfo.total.toExact()),
+      };
+    })
+    .sort((a, b) => b.percentageAllocation - a.percentageAllocation);
+
+  return enhancedWalletData;
+}
 
 function ReportAssetLink({ asset }: { asset: Asset }) {
   return (
@@ -101,7 +171,7 @@ function ShareAssetLink({ asset }: { asset: Asset }) {
 }
 
 export function AssetInfo() {
-  const { asset_code } = useParams();
+  const { asset_code, standardizedTokenId } = useParams();
   invariant(asset_code, 'Asset Code is required');
   const navigationType = useNavigationType();
   useEffect(() => {
@@ -110,6 +180,17 @@ export function AssetInfo() {
     }
   }, [navigationType]);
   useBackgroundKind(whiteBackgroundKind);
+
+  const { fungibleTokenBalances, isLoading: isLoadingFungibleTokenBalances } =
+    useGetFungibleTokenBalances(
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      [standardizedTokenId ?? '']
+    );
 
   const { currency } = useCurrency();
   const { data: assetFullInfoData, isLoading } = useAssetFullInfo(
@@ -155,10 +236,27 @@ export function AssetInfo() {
     },
   });
 
-  const chainWithTheBiggestBalance =
-    walletData?.data?.chainsDistribution?.at(0)?.chain.id || NetworkId.Zero;
+  const tokensInfo = useMemo(() => {
+    return fungibleTokenBalances?.find(
+      (balance) => balance.standardizedTokenId === standardizedTokenId
+    );
+  }, [fungibleTokenBalances, standardizedTokenId]);
 
-  if (isLoading || !wallet || !walletData) {
+  // Convert tokensInfo to walletAssetDetails format
+  const convertedWalletAssetDetails = useMemo(() => {
+    return convertTokensInfoToWalletAssetDetails(tokensInfo, walletData?.data);
+  }, [tokensInfo, walletData?.data]);
+
+  const chainWithTheBiggestBalance =
+    convertedWalletAssetDetails?.chainsDistribution?.at(0)?.chain.id ||
+    NetworkId.Zero;
+
+  if (
+    isLoading ||
+    !wallet ||
+    !convertedWalletAssetDetails ||
+    isLoadingFungibleTokenBalances
+  ) {
     return (
       <>
         <NavigationTitle title={null} documentTitle={`${asset_code} - info`} />
@@ -172,7 +270,7 @@ export function AssetInfo() {
   invariant(assetFullInfo?.fungible, 'Fungible asset info is missing');
 
   const isWatchedAddress = isReadonlyAccount(wallet);
-  const isEmptyBalance = walletData?.data.totalValue === 0;
+  const isEmptyBalance = convertedWalletAssetDetails.totalValue === 0;
 
   const chainForSwap = isEmptyBalance
     ? assetFullInfo.extra.mainChain
@@ -210,7 +308,7 @@ export function AssetInfo() {
           address={params.address}
           wallet={wallet}
           assetFullInfo={assetFullInfo}
-          walletAssetDetails={walletData.data}
+          walletAssetDetails={convertedWalletAssetDetails}
           assetAddressPnlQuery={assetAddressPnlQuery}
         />
         <AssetResources assetFullInfo={assetFullInfo} />
@@ -240,8 +338,8 @@ export function AssetInfo() {
               as={UnstyledLink}
               to={
                 isEmptyBalance
-                  ? `/swap-form?inputChain=${chainForSwap}&outputFungibleId=${asset_code}`
-                  : `/swap-form?inputChain=${chainForSwap}&inputFungibleId=${asset_code}`
+                  ? `/swap-form?inputChain=${chainForSwap}&outputFungibleId=${asset_code}&standardizedTokenId=${standardizedTokenId}`
+                  : `/swap-form?inputChain=${chainForSwap}&inputFungibleId=${asset_code}&standardizedTokenId=${standardizedTokenId}`
               }
             >
               <HStack gap={8} alignItems="center" justifyContent="center">
@@ -255,7 +353,7 @@ export function AssetInfo() {
                   as={UnstyledLink}
                   kind="primary"
                   size={48}
-                  to={`/send-form?tokenAssetCode=${asset_code}&tokenChain=${chainWithTheBiggestBalance}`}
+                  to={`/send-form?tokenAssetCode=${asset_code}&tokenChain=${chainWithTheBiggestBalance}&standardizedTokenId=${standardizedTokenId}`}
                   style={{ padding: 14 }}
                   aria-label="Send Token"
                 >
@@ -264,7 +362,7 @@ export function AssetInfo() {
                 <Button
                   kind="primary"
                   as={UnstyledLink}
-                  to={`/bridge-form?inputFungibleId=${asset_code}&inputChain=${chainWithTheBiggestBalance}`}
+                  to={`/bridge-form?inputFungibleId=${asset_code}&inputChain=${chainWithTheBiggestBalance}&standardizedTokenId=${standardizedTokenId}`}
                   size={48}
                   style={{ padding: 14 }}
                   aria-label="Bridge Token"

--- a/src/ui/pages/Overview/Overview.tsx
+++ b/src/ui/pages/Overview/Overview.tsx
@@ -71,6 +71,8 @@ import { VStack } from 'src/ui/ui-kit/VStack';
 import { getAddressType } from 'src/shared/wallet/classifiers';
 import { NetworkSelectValue } from 'src/modules/networks/NetworkSelectValue';
 import { useEnableChainAbstraction } from 'src/shared/core/useEnableChainAbstraction';
+import { useGetPortfolioOverview } from '@orb-labs/orby-react';
+import { useIsChainAbstractionEnabled } from 'src/shared/core/useIsChainAbstractionEnabled';
 import { ViewSuspense } from '../../components/ViewSuspense';
 import { WalletAvatar } from '../../components/WalletAvatar';
 import { Feed } from '../Feed';
@@ -351,7 +353,7 @@ function formatPercentChange(value: number, locale: string): PercentChangeInfo {
   };
 }
 
-function OverviewComponent() {
+export function OverviewComponent() {
   useBodyStyle(
     useMemo(() => ({ ['--background' as string]: 'var(--z-index-0)' }), [])
   );
@@ -390,6 +392,24 @@ function OverviewComponent() {
     { enabled: ready, refetchInterval: 40000 }
   );
   const walletPortfolio = data?.data;
+
+  const isChainAbstracted = useIsChainAbstractionEnabled();
+  const { fungibleTokenOverview: unifiedPortfolio } = useGetPortfolioOverview(
+    preferences?.testnetMode?.on,
+    undefined
+  );
+
+  const walletPortfolioInFiat = useMemo(() => {
+    if (isChainAbstracted) {
+      return unifiedPortfolio?.totalValueInFiat?.toExact() ?? 0;
+    } else {
+      return walletPortfolio?.totalValue;
+    }
+  }, [
+    isChainAbstracted,
+    unifiedPortfolio?.totalValueInFiat,
+    walletPortfolio?.totalValue,
+  ]);
 
   const percentageChangeValue = walletPortfolio?.change24h.relative;
   const percentageChange = useMemo(
@@ -605,10 +625,10 @@ function OverviewComponent() {
           ) : null}
           <VStack gap={0}>
             <UIText kind="headline/h1">
-              {walletPortfolio?.totalValue != null ? (
+              {walletPortfolioInFiat != null ? (
                 <NeutralDecimals
                   parts={formatCurrencyToParts(
-                    walletPortfolio.totalValue,
+                    walletPortfolioInFiat,
                     'en',
                     currency
                   )}

--- a/src/ui/pages/Overview/Positions/Positions.tsx
+++ b/src/ui/pages/Overview/Positions/Positions.tsx
@@ -1,4 +1,5 @@
-import type { AddressPosition, AddressPositionDappInfo } from 'defi-sdk';
+import type { AddressPositionDappInfo } from 'defi-sdk';
+import type { AddressPositionWithStandardizedTokenId } from 'src/shared/types/AddressPositionWithStandardizedTokenId';
 import React, { useCallback, useMemo, useState } from 'react';
 import {
   formatCurrencyToParts,
@@ -69,6 +70,16 @@ import { openHrefInTabIfSidepanel } from 'src/ui/shared/openInTabIfInSidepanel';
 import { useFirebaseConfig } from 'src/modules/remote-config/plugins/useFirebaseConfig';
 import { isSolanaAddress } from 'src/modules/solana/shared';
 import { getAddressType } from 'src/shared/wallet/classifiers';
+import { useIsChainAbstractionEnabled } from 'src/shared/core/useIsChainAbstractionEnabled';
+import {
+  useGetFungibleTokenPortfolio,
+  useGetPortfolioOverview,
+  useOrby,
+} from '@orb-labs/orby-react';
+import {
+  createChainAddressToStandardizedBalanceMap,
+  processUnifiedPositions,
+} from 'src/shared/converters';
 import {
   TAB_SELECTOR_HEIGHT,
   TAB_TOP_PADDING,
@@ -142,7 +153,7 @@ function AddressPositionItem({
   groupType,
   showGasIcon,
 }: {
-  position: AddressPosition;
+  position: AddressPositionWithStandardizedTokenId;
   groupType: PositionsGroupType;
   hasPreviosNestedPosition?: boolean;
   showGasIcon?: boolean;
@@ -292,7 +303,7 @@ function AddressPositionItem({
 
 interface PreparedPositions {
   gasPositionId: string | null;
-  items: AddressPosition[];
+  items: AddressPositionWithStandardizedTokenId[];
   totalValue: number;
   dappIds: string[];
   dappIndex: Record<
@@ -300,9 +311,9 @@ interface PreparedPositions {
     {
       totalValue: number;
       relativeValue: number;
-      items: AddressPosition[];
+      items: AddressPositionWithStandardizedTokenId[];
       names: string[];
-      nameIndex: Record<string, AddressPosition[]>;
+      nameIndex: Record<string, AddressPositionWithStandardizedTokenId[]>;
     }
   >;
 }
@@ -313,7 +324,7 @@ function usePreparedPositions({
   moveGasPositionToFront,
   dappChain,
 }: {
-  items: AddressPosition[];
+  items: AddressPositionWithStandardizedTokenId[];
   groupType: PositionsGroupType;
   moveGasPositionToFront: boolean;
   dappChain: string | null;
@@ -443,7 +454,7 @@ function PositionList({
   moveGasPositionToFront,
   dappChain,
 }: {
-  items: AddressPosition[];
+  items: AddressPositionWithStandardizedTokenId[];
   address: string | null;
   moveGasPositionToFront: boolean;
   dappChain: string | null;
@@ -546,7 +557,7 @@ function PositionList({
               // TODO: remove this conditional when we have Asset Page 100% enabled in extension
               component: assetPageEnabled ? (
                 <SurfaceItemLink
-                  to={`/asset/${position.asset.id}`}
+                  to={`/asset/${position.asset.id}/${position.standardizedTokenId}`}
                   decorationStyle={{ borderRadius: 16 }}
                 >
                   {itemContent}
@@ -661,6 +672,112 @@ function PositionList({
           </VStack>
         );
       })}
+    </VStack>
+  );
+}
+
+function UnifiedPositions({
+  address,
+  selectedChain,
+  dappChain,
+  onChainChange,
+  renderEmptyView,
+  renderLoadingView,
+  portfolioDecomposition,
+  ...positionListProps
+}: {
+  address: string;
+  renderEmptyView: () => React.ReactNode;
+  renderLoadingView: () => React.ReactNode;
+  dappChain: string | null;
+  selectedChain: string | null;
+  onChainChange: (value: string | null) => void;
+  portfolioDecomposition: WalletPortfolio | null;
+} & Omit<React.ComponentProps<typeof PositionList>, 'items'>) {
+  const { currency } = useCurrency();
+  const { preferences } = usePreferences();
+  const { fungibleTokenOverview } = useGetPortfolioOverview(
+    preferences?.testnetMode?.on ?? false
+  );
+
+  const { fungibleTokens, isLoading: isLoadingFungibleTokens } =
+    useGetFungibleTokenPortfolio(preferences?.testnetMode?.on ?? false);
+
+  const { accountCluster } = useOrby();
+  const { networks } = useNetworks();
+  const addresses = useMemo(() => {
+    return (accountCluster?.accounts ?? []).map((account) => account.address);
+  }, [accountCluster]);
+
+  const { data, isLoading } = useHttpAddressPositions(
+    { addresses, currency },
+    { source: useHttpClientSource() },
+    { refetchInterval: usePositionsRefetchInterval(40000) }
+  );
+
+  // Create a map of {chainId}+{address} to StandardizedBalance
+  const chainAddressToStandardizedBalanceMap = useMemo(() => {
+    return createChainAddressToStandardizedBalanceMap(fungibleTokens);
+  }, [fungibleTokens]);
+
+  const positions = useMemo(() => {
+    return processUnifiedPositions({
+      positions: data?.data,
+      chainAddressToStandardizedBalanceMap,
+      networks: networks || undefined,
+    });
+  }, [chainAddressToStandardizedBalanceMap, data?.data, networks]);
+
+  const chainValue = selectedChain || dappChain || NetworkSelectValue.Unified;
+
+  const items = useMemo(
+    () =>
+      positions?.filter(
+        (position) =>
+          (position.type === 'asset' ? position.is_displayable : true) &&
+          (chainValue === NetworkSelectValue.All ||
+            chainValue === NetworkSelectValue.Unified ||
+            position.chain === chainValue)
+      ),
+    [chainValue, positions]
+  );
+
+  const groupedPositions = groupPositionsByDapp(items);
+
+  if (isLoading || isLoadingFungibleTokens) {
+    return renderLoadingView() as JSX.Element;
+  }
+  if (!items || items.length === 0) {
+    return renderEmptyView() as JSX.Element;
+  }
+
+  return (
+    <VStack gap={Object.keys(groupedPositions).length > 1 ? 16 : 8}>
+      <div style={{ paddingInline: 16 }}>
+        <NetworkBalance
+          standard={getAddressType(address)}
+          dappChain={dappChain}
+          selectedChain={selectedChain}
+          onChange={onChainChange}
+          value={
+            fungibleTokenOverview?.totalValueInFiat ? (
+              <NeutralDecimals
+                parts={formatCurrencyToParts(
+                  fungibleTokenOverview?.totalValueInFiat?.toExact() || 0,
+                  'en',
+                  currency
+                )}
+              />
+            ) : null
+          }
+        />
+      </div>
+      <PositionList
+        items={items}
+        dappChain={dappChain}
+        address={address}
+        {...positionListProps}
+      />
     </VStack>
   );
 }
@@ -869,6 +986,13 @@ export function Positions({
   const { networks, isLoading } = useNetworks(
     positionChains.length ? positionChains : undefined
   );
+
+  const isChainAbstracted = useIsChainAbstractionEnabled();
+
+  const displayUnifiedPositions = useMemo(() => {
+    return isChainAbstracted && chainValue === NetworkSelectValue.Unified;
+  }, [chainValue, isChainAbstracted]);
+
   if (!ready) {
     return (
       <CenteredFillViewportView
@@ -961,7 +1085,20 @@ export function Positions({
   if (!readyToRender) {
     return renderEmptyViewForNetwork();
   }
-  if (isSupportedByBackend) {
+  if (displayUnifiedPositions) {
+    return (
+      <UnifiedPositions
+        address={singleAddressNormalized}
+        dappChain={dappChain}
+        selectedChain={selectedChain}
+        moveGasPositionToFront={moveGasPositionToFront}
+        onChainChange={onChainChange}
+        renderEmptyView={renderEmptyViewForNetwork}
+        renderLoadingView={renderLoadingViewForNetwork}
+        portfolioDecomposition={walletPortfolio || null}
+      />
+    );
+  } else if (isSupportedByBackend) {
     return (
       <MultiChainPositions
         address={singleAddressNormalized}


### PR DESCRIPTION
This PR is part of the steps to add Orby chain abstraction on the Zerion Chrome Extension. The same steps and similar code can be used on other Chrome Extension wallets.

[✅] Step 0 PR(https://github.com/orb-labs/zerion-wallet-extension/pull/15): Setup feature flags
- create a remotely configurable feature flag called chain_abstraction_enabled. we will use this feature flag to gate access to the chain abstraction as we do progressive rollout of the feature.
Zerion uses firebase but you can feature flag system of your choice such as launch darkly

[✅] Step 1: Update Update OrbyConfig to include the other VM accounts and update signing of operations
- get all the addresses and accounts that you want to include together. For this Zerion example, we want to include all the accounts that are part of the same wallet group. That means account that are derived from the same mnemonic are grouped together regardless of the VM that they are part of. Specifically, Zerion supports both EVM and SVM, so we will have chain abstraction and unified balances on the SVM and EVM
- update the signing operations to fetch a signer based on the address that the operation is from
- use the feature flag from step 0 to turn on chain abstraction on Orby. When the feature flag is on, turn on chain abstraction on Orby for the user

Testing: At this point, we should have chain abstraction enabled for the accounts we set in the OrbyConfig
- import an account to Zerion using a mnemonic
- Connect to uniswap. You should see unified balances on the app across SVM and EVM. Also, you should be able to perform a transaction using the unified balances
- Connect jupiter (e.g. https://jup.ag/swap?sell=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&buy=So11111111111111111111111111111111111111112) you should also see your balances unified across EVM and SVM. Also, you should be able to perform a transaction using the unified balances

[✅] Step 2 PR(https://github.com/orb-labs/zerion-wallet-extension/pull/16): Introduce unified network and make it default
We want to separate the chain that the connected app is on from the chain / view that the user is on. To do that, we introduce the notion of `selectedChain` in the app preferences. This value can be updated/changed by the user and it is set to `NetworkSelectValue.Unified` by default. When an app ask for a chain switch, we update the `selectedChain` iff its current value is not `NetworkSelectValue.Unified`. 

Not, we do not seek to remove all the chains and allow user to be able to select `All Networks` and separate networks because we want to allow the option for users to see a particular view they want. Here is now the wallet looks with these changes:
<img width="369" height="470" alt="Screenshot 2025-07-22 at 11 57 52" src="https://github.com/user-attachments/assets/daae60ac-f96a-43da-96d3-f58d7fe3eb12" />

<img width="355" height="101" alt="Screenshot 2025-07-22 at 11 58 09" src="https://github.com/user-attachments/assets/74252f84-d7ab-4485-9264-ae9ff885d82f" />

<img width="367" height="97" alt="Screenshot 2025-07-22 at 11 58 27" src="https://github.com/user-attachments/assets/493cf6c7-e485-461c-9424-105416043c1d" />

[👉] Step 3: Displaying a unified Portfolio view
When `selectedChain` is `NetworkSelectValue.Unified`, we want to display a unified view and total assets. Specifically, we want to keep the data data models that the wallet was already using. So, we:
1. fetch balances from wallet backend as we normally do
2. fetch balances from Orby
3. merge the 2 but prioritizing assets from the wallet backend. We only want orby balances for the total and breakdown but everything else stays the same.

This give us a view that looks like the following
<img width="361" height="783" alt="Screenshot 2025-07-22 at 14 01 58" src="https://github.com/user-attachments/assets/9951ba02-a235-4180-a276-ab27fe89a4ae" />

<img width="363" height="832" alt="Screenshot 2025-07-22 at 14 02 38" src="https://github.com/user-attachments/assets/9cbb997f-46aa-416d-990d-613f90d264fc" />

<img width="360" height="703" alt="Screenshot 2025-07-22 at 14 02 16" src="https://github.com/user-attachments/assets/81cd65c1-1c6f-4d20-94dc-bf54b2231e5e" />



