### PR TITLE
ca-step 4: in-wallet chain abstracted sends

### DIFF
--- a/src/ui/pages/BridgeForm/BridgeForm.tsx
+++ b/src/ui/pages/BridgeForm/BridgeForm.tsx
@@ -71,7 +71,7 @@ import { PageBottom } from 'src/ui/components/PageBottom';
 import { whiteBackgroundKind } from 'src/ui/components/Background/Background';
 import { useGasbackEstimation } from 'src/modules/ethereum/account-abstraction/rewards';
 import type { QuotesData } from 'src/ui/shared/requests/useQuotes';
-import { useQuotes2 } from 'src/ui/shared/requests/useQuotes';
+import { useSortedQuotes } from 'src/ui/shared/requests/useSortedQuotes';
 import type { Quote2 } from 'src/shared/types/Quote';
 import {
   toIncomingTransaction,
@@ -123,19 +123,6 @@ import { LabeledNetworkSelect } from './LabeledNetworkSelect';
 import { BridgeLine } from './BridgeLine';
 import { ZerionFeeLine } from './ZerionFeeLine';
 import { ReceiverAddressField } from './ReceiverAddressField';
-
-function useSortedQuotes(params: Parameters<typeof useQuotes2>[0]) {
-  return {
-    quotesByAmount: useQuotes2({
-      ...params,
-      formState: { ...params.formState, sort: '1' },
-    }),
-    quotesByTime: useQuotes2({
-      ...params,
-      formState: { ...params.formState, sort: '2' },
-    }),
-  };
-}
 
 const rootNode = getRootDomNode();
 

--- a/src/ui/pages/SendForm/AssetSelect/AssetSelect.tsx
+++ b/src/ui/pages/SendForm/AssetSelect/AssetSelect.tsx
@@ -42,6 +42,7 @@ import { useCurrency } from 'src/modules/currency/useCurrency';
 import GasIcon from 'jsx:src/ui/assets/gas.svg';
 import { useNetworks } from 'src/modules/networks/useNetworks';
 import type { BareAddressPosition } from 'src/shared/types/BareAddressPosition';
+import { useIsChainAbstractionEnabled } from 'src/shared/core/useIsChainAbstractionEnabled';
 import * as styles from './styles.module.css';
 
 function ResultItem({
@@ -454,12 +455,18 @@ function AssetSelectComponent({
     }, 100);
   }, [firstItem, selectItem, setHighlightedIndex]);
 
-  const assetExistsOnChain =
-    chain &&
-    getAssetImplementationInChain({
-      asset: selectedItem.asset,
-      chain,
-    });
+  const isChainAbstractionEnabled = useIsChainAbstractionEnabled();
+
+  const assetExistsOnChain = useMemo(() => {
+    if (isChainAbstractionEnabled) {
+      return true;
+    }
+
+    return (
+      chain &&
+      getAssetImplementationInChain({ asset: selectedItem.asset, chain })
+    );
+  }, [chain, selectedItem.asset, isChainAbstractionEnabled]);
 
   const { networks } = useNetworks();
   const gasAssetId = useMemo(() => {

--- a/src/ui/pages/SwapForm/SwapForm.tsx
+++ b/src/ui/pages/SwapForm/SwapForm.tsx
@@ -96,9 +96,13 @@ import { ensureSolanaResult } from 'src/modules/shared/transactions/helpers';
 import { isMatchForEcosystem } from 'src/shared/wallet/shared';
 import { Networks } from 'src/modules/networks/Networks';
 import { useIsOrbyEnabled } from 'src/shared/core/useIsOrbyEnabled';
-import { useGetFungibleTokenPortfolio, useOrby } from '@orb-labs/orby-react';
+import {
+  useGetFungibleTokenBalances,
+  useGetFungibleTokenPortfolio,
+  useOrby,
+} from '@orb-labs/orby-react';
 import type { OperationStatus } from '@orb-labs/orby-core';
-import { OperationStatusType } from '@orb-labs/orby-core';
+import { OperationStatusType, VMType } from '@orb-labs/orby-core';
 import {
   signTransaction,
   signTypedData,
@@ -106,6 +110,12 @@ import {
 } from 'src/shared/core/orb';
 import _ from 'lodash';
 import { useOrbyGetOperationsToSignTransactionOrSignTypedData } from 'src/ui/shared/hooks/useOrbyGetOperationsToSignTransactionOrSignTypedData';
+import { useSortedQuotes } from 'src/ui/shared/requests/useSortedQuotes';
+import {
+  createChainAddressToStandardizedBalanceMap,
+  processUnifiedPositions,
+} from 'src/shared/converters';
+import { useIsChainAbstractionEnabled } from 'src/shared/core/useIsChainAbstractionEnabled';
 import { NetworkSelect } from '../Networks/NetworkSelect';
 import { TransactionConfiguration } from '../SendTransaction/TransactionConfiguration';
 import { txErrorToMessage } from '../SendTransaction/shared/transactionErrorToMessage';
@@ -287,7 +297,10 @@ type HandleChangeFunction = <K extends keyof SwapFormState>(
   value: SwapFormState[K]
 ) => void;
 
-function reverseTokens(state: SwapFormState) {
+function reverseTokens(
+  state: SwapFormState,
+  allPositions?: AddressPosition[] | null | undefined
+) {
   const { outputFungibleId, inputFungibleId } = state;
   const newState: SwapFormState = {};
   if (outputFungibleId) {
@@ -296,22 +309,54 @@ function reverseTokens(state: SwapFormState) {
   if (inputFungibleId) {
     newState.outputFungibleId = inputFungibleId;
   }
+
+  const inputChain = allPositions?.find(
+    (p) => p.asset.id == newState.inputFungibleId
+  )?.chain;
+
+  if (inputChain) {
+    newState.inputChain = inputChain;
+  }
+
+  const outputChain = allPositions?.find(
+    (p) => p.asset.id == newState.outputFungibleId
+  )?.chain;
+
+  if (outputChain) {
+    newState.outputChain = outputChain;
+  }
+
   return newState;
 }
 
 function changeAssetId<K extends keyof SwapFormState>(
   state: SwapFormState,
   key: K,
-  value: SwapFormState[K]
+  value: SwapFormState[K],
+  allPositions?: AddressPosition[] | null | undefined
 ) {
   const isSameAsOpposite =
     (key === 'inputFungibleId' && value === state.outputFungibleId) ||
     (key === 'outputFungibleId' && value === state.inputFungibleId);
   if (isSameAsOpposite) {
-    const newState = reverseTokens(state);
+    const newState = reverseTokens(state, allPositions);
     newState[key] = value;
     return newState;
   } else {
+    if (key === 'inputFungibleId') {
+      const inputChain = allPositions?.find((p) => p.asset.id == value)?.chain;
+
+      if (inputChain) {
+        return { [key]: value, inputChain };
+      }
+    } else if (key === 'outputFungibleId') {
+      const outputChain = allPositions?.find((p) => p.asset.id == value)?.chain;
+
+      if (outputChain) {
+        return { [key]: value, outputChain };
+      }
+    }
+
     return { [key]: value };
   }
 }
@@ -339,18 +384,38 @@ function SwapFormComponent() {
   ] = useState<OperationStatus | undefined>(undefined);
   const [userFormState, setUserFormState] = useSearchParamsObj<SwapFormState>();
 
+  const { accountCluster } = useOrby();
+  const isChainAbstractionEnabled = useIsChainAbstractionEnabled();
+  const { preferences } = usePreferences();
+  const { fungibleTokenBalances } = useGetFungibleTokenBalances(false);
+  const { networks } = useNetworks();
+
+  const addresses = useMemo(() => {
+    if (isChainAbstractionEnabled) {
+      return (accountCluster?.accounts ?? []).map((account) => account.address);
+    }
+
+    return [singleAddressNormalized];
+  }, [
+    accountCluster?.accounts,
+    isChainAbstractionEnabled,
+    singleAddressNormalized,
+  ]);
+
   const refetchInterval = usePositionsRefetchInterval(20000);
   const httpAddressPositionsQuery = useHttpAddressPositions(
-    { addresses: [singleAddressNormalized], currency },
+    { addresses: addresses, currency },
     { source: useHttpClientSource() },
     { refetchInterval }
   );
   /** All backend-known positions across all _supported_ chains */
-  const allPositions = httpAddressPositionsQuery.data?.data || null;
+  const nonChainAbstractionPositions =
+    httpAddressPositionsQuery.data?.data || null;
   const { data: positionsOnSupportedChains } = useQuery({
-    queryKey: ['positionsOnSupportedChains', allPositions],
-    queryFn: () => filterSupportedPositionsOnSupportedChains(allPositions),
-    enabled: Boolean(allPositions),
+    queryKey: ['positionsOnSupportedChains', nonChainAbstractionPositions],
+    queryFn: () =>
+      filterSupportedPositionsOnSupportedChains(nonChainAbstractionPositions),
+    enabled: Boolean(nonChainAbstractionPositions),
     keepPreviousData: true,
   });
 
@@ -389,46 +454,146 @@ function SwapFormComponent() {
       keepPreviousData: true,
     });
 
-  const formState: SwapFormState = useMemo(
-    () => ({ ...defaultState, ...preState }),
-    [defaultState, preState]
-  );
+  const formState: SwapFormState = useMemo(() => {
+    if (isChainAbstractionEnabled) {
+      const inputFungibleId =
+        preState.inputFungibleId ?? defaultState.inputFungibleId;
+
+      const outputFungibleId =
+        preState.outputFungibleId ?? defaultState.outputFungibleId;
+
+      const inputChain = nonChainAbstractionPositions?.find(
+        (p) => p.asset.id == inputFungibleId
+      )?.chain;
+
+      const outputChain = nonChainAbstractionPositions?.find(
+        (p) => p.asset.id == outputFungibleId
+      )?.chain;
+
+      if (inputChain && outputChain) {
+        return { ...defaultState, ...preState, inputChain, outputChain };
+      } else if (inputChain) {
+        return { ...defaultState, ...preState, inputChain };
+      } else if (outputChain) {
+        return { ...defaultState, ...preState, outputChain };
+      } else {
+        return { ...defaultState, ...preState };
+      }
+    }
+
+    return { ...defaultState, ...preState };
+  }, [
+    isChainAbstractionEnabled,
+    defaultState,
+    preState,
+    nonChainAbstractionPositions,
+  ]);
 
   const handleChange = useCallback<HandleChangeFunction>(
     (key, value) => setUserFormState((state) => ({ ...state, [key]: value })),
     [setUserFormState]
   );
 
+  // Create a map of {chainId}+{address} to StandardizedBalance
+  const chainAddressToStandardizedBalanceMap = useMemo(() => {
+    return createChainAddressToStandardizedBalanceMap(fungibleTokenBalances);
+  }, [fungibleTokenBalances]);
+
+  const allPositions = useMemo(() => {
+    if (isChainAbstractionEnabled) {
+      return processUnifiedPositions({
+        positions: nonChainAbstractionPositions || undefined,
+        chainAddressToStandardizedBalanceMap,
+        networks: networks || undefined,
+      });
+    }
+
+    return nonChainAbstractionPositions;
+  }, [
+    isChainAbstractionEnabled,
+    nonChainAbstractionPositions,
+    chainAddressToStandardizedBalanceMap,
+    networks,
+  ]);
+
+  const availablePositions = useMemo(() => {
+    if (isChainAbstractionEnabled) {
+      return sortPositionsByValue(allPositions);
+    }
+
+    const positions = allPositions
+      ?.filter((p) => p.chain === preferences?.selectedChain?.toString())
+      .filter((p) => p.type === 'asset');
+
+    return sortPositionsByValue(positions);
+  }, [allPositions, preferences, isChainAbstractionEnabled]);
+
   /** Same as handleChange, but reverses tokens if selected asset is same as the opposite one */
   const handleAssetChange = useEvent<HandleChangeFunction>((key, value) => {
     setUserFormState((state) => ({
       ...state,
-      ...changeAssetId(formState, key, value),
+      ...changeAssetId(formState, key, value, availablePositions),
     }));
   });
 
-  const { inputAmount, inputFungibleId, inputChain, outputFungibleId } =
-    formState;
+  const { inputAmount, inputFungibleId, outputFungibleId } = formState;
+  const { inputChainId, inputChain, outputChain } = useMemo(() => {
+    const inputChain = formState.inputChain
+      ? createChain(formState.inputChain)
+      : null;
 
-  const availablePositions = useMemo(() => {
-    const positions = allPositions
-      ?.filter((p) => p.chain === inputChain)
-      .filter((p) => p.type === 'asset');
-    return sortPositionsByValue(positions);
-  }, [allPositions, inputChain]);
+    const outputChain = formState.outputChain
+      ? createChain(formState.outputChain)
+      : inputChain;
 
-  const spendChain = inputChain ? createChain(inputChain) : null;
-  const { data: network } = useNetworkConfig(inputChain ?? null);
+    const id =
+      inputChain?.value == 'solana'
+        ? 101
+        : inputChain?.value && networks
+        ? networks.getChainId(inputChain)
+        : null;
+
+    return {
+      inputChainId: id ? BigInt(id) : undefined,
+      inputChain: inputChain,
+      outputChain,
+    };
+  }, [formState.inputChain, formState.outputChain, networks]);
+
+  const isOrbyEnabled = useIsOrbyEnabled(inputChainId);
+  const getPortFolioParams = useMemo(() => {
+    if (isChainAbstractionEnabled) {
+      return {
+        isTestnetMode: preferences?.testnetMode?.on,
+        chainId: undefined,
+      };
+    }
+
+    return { isTestnetMode: undefined, inputChainId };
+  }, [isChainAbstractionEnabled, inputChainId, preferences]);
+
+  const { data: network } = useNetworkConfig(inputChain?.value ?? null);
 
   const inputPosition = usePosition({
     assetId: inputFungibleId ?? null,
-    positions: allPositions,
-    chain: spendChain,
+    positions: allPositions ?? null,
+    chain: inputChain,
   });
   const outputPosition = usePosition({
     assetId: outputFungibleId ?? null,
-    positions: allPositions,
-    chain: spendChain,
+    positions: allPositions ?? null,
+    chain: outputChain,
+  });
+
+  const { fungibleTokens } = useGetFungibleTokenPortfolio(
+    getPortFolioParams.isTestnetMode,
+    getPortFolioParams.chainId
+  );
+
+  const [selectedGasToken, setSelectedGasToken] = useState<GasTokenInput>({
+    name: 'Native Token',
+    standardizedTokenId: undefined,
+    isDefault: true,
   });
 
   const allowanceDialogRef = useRef<HTMLDialogElementInterface | null>(null);
@@ -444,24 +609,58 @@ function SwapFormComponent() {
     network && isMatchForEcosystem(address, Networks.getEcosystem(network));
   const inputChainAddressMismatch = network && !inputChainAddressMatch;
 
-  const quotesData = useQuotes2({
-    address: singleAddressNormalized,
+  // Check if input and output positions are on different chains
+  const isCrossChain =
+    inputChain && outputChain && inputChain.value !== outputChain.value;
+
+  const updatedSingleAddressNormalized = useMemo(() => {
+    if (inputChain?.value === 'solana') {
+      return (
+        accountCluster?.accounts?.find(
+          (account) => account.vmType == VMType.SVM
+        )?.address ?? singleAddressNormalized
+      );
+    }
+
+    return (
+      accountCluster?.accounts?.find((account) => account.vmType == VMType.EVM)
+        ?.address ?? singleAddressNormalized
+    );
+  }, [inputChain?.value, accountCluster?.accounts, singleAddressNormalized]);
+
+  const sortedQuotes = useSortedQuotes({
+    address: updatedSingleAddressNormalized,
+    currency,
+    formState,
+    enabled: Boolean(
+      defaultStateQuery.isFetched &&
+        !defaultStateQuery.isPreviousData &&
+        isCrossChain
+    ),
+  });
+
+  const regularQuotes = useQuotes2({
+    address: updatedSingleAddressNormalized,
     currency,
     formState,
     enabled:
       defaultStateQuery.isFetched &&
       !defaultStateQuery.isPreviousData &&
-      inputChainAddressMatch,
+      inputChainAddressMatch &&
+      !isCrossChain,
   });
+
+  // Use sorted quotes for cross-chain swaps, regular quotes for same-chain swaps
+  const quotesData = isCrossChain ? sortedQuotes.quotesByAmount : regularQuotes;
   const { refetch: refetchQuotes } = quotesData;
 
   const [userQuoteId, setUserQuoteId] = useState<string | null>(null);
   useEffect(() => {
     setUserQuoteId(null);
-  }, [inputAmount, inputFungibleId, outputFungibleId, inputChain]);
+  }, [inputAmount, inputFungibleId, outputFungibleId]);
 
   const selectedQuote = useMemo(() => {
-    const userQuote = quotesData.quotes?.find(
+    const userQuote = quotesData?.quotes?.find(
       (quote) => quote.contractMetadata?.id === userQuoteId
     );
     const defaultQuote = quotesData.quotes?.[0];
@@ -476,35 +675,6 @@ function SwapFormComponent() {
     supportsSponsoredTransactions: network?.supports_sponsored_transactions,
   });
 
-  const { accountCluster } = useOrby();
-  const { networks } = useNetworks(
-    inputChain ? [inputChain.toString()] : undefined
-  );
-
-  const chain = useMemo(() => {
-    if (inputChain) {
-      return createChain(inputChain);
-    }
-    return null;
-  }, [inputChain]);
-
-  const chainId = useMemo(() => {
-    const id =
-      inputChain == 'solana'
-        ? 101
-        : chain && networks
-        ? networks.getChainId(chain)
-        : null;
-
-    if (id) {
-      return BigInt(id);
-    }
-    return undefined;
-  }, [chain, inputChain, networks]);
-
-  const isOrbyEnabled = useIsOrbyEnabled(chainId);
-  const { fungibleTokens } = useGetFungibleTokenPortfolio(undefined, chainId);
-
   const currentTransaction = useMemo(() => {
     if (isOrbyEnabled) {
       return selectedQuote?.transactionSwap || null;
@@ -516,12 +686,6 @@ function SwapFormComponent() {
       );
     }
   }, [selectedQuote, isOrbyEnabled]);
-
-  const [selectedGasToken, setSelectedGasToken] = useState<GasTokenInput>({
-    name: 'Native Token',
-    standardizedTokenId: undefined,
-    isDefault: true,
-  });
 
   const {
     operationSet,
@@ -538,7 +702,7 @@ function SwapFormComponent() {
     wallet ? wallet : undefined,
     isOrbyEnabled,
     selectedGasToken,
-    chainId
+    inputChainId
   );
 
   const selectGasToken = useCallback(
@@ -566,7 +730,7 @@ function SwapFormComponent() {
         'Approval transaction is not configured'
       );
 
-      invariant(spendChain, 'Chain must be defined to sign the tx');
+      invariant(inputChain, 'Chain must be defined to sign the tx');
       invariant(approveTxBtnRef.current, 'SignTransactionButton not found');
       invariant(inputPosition, 'Spend position must be defined');
       invariant(formState.inputAmount, 'inputAmount must be set');
@@ -580,7 +744,7 @@ function SwapFormComponent() {
 
       const inputAmountBase = commonToBase(
         formState.inputAmount,
-        getDecimals({ asset: inputPosition.asset, chain: spendChain })
+        getDecimals({ asset: inputPosition.asset, chain: inputChain })
       ).toFixed();
 
       const fallbackAddressAction = selectedQuote.transactionApprove.evm
@@ -590,13 +754,13 @@ function SwapFormComponent() {
             ),
             asset: inputPosition.asset,
             quantity: inputAmountBase,
-            chain: spendChain,
+            chain: inputChain,
           })
         : null;
 
       const txResponse = await approveTxBtnRef.current.sendTransaction({
         transaction: { evm: toIncomingTransaction(approvalTx) },
-        chain: spendChain.toString(),
+        chain: inputChain.toString(),
         initiator: INTERNAL_ORIGIN,
         clientScope: 'Swap',
         feeValueCommon: selectedQuote.networkFee?.amount.quantity ?? null,
@@ -636,7 +800,7 @@ function SwapFormComponent() {
         'Cannot submit transaction without a quote'
       );
       const { inputAmount } = formState;
-      invariant(spendChain, 'Chain must be defined to sign the tx');
+      invariant(inputChain, 'Chain must be defined to sign the tx');
       invariant(inputAmount, 'inputAmount must be set');
       invariant(
         inputPosition && outputPosition,
@@ -645,29 +809,29 @@ function SwapFormComponent() {
       invariant(sendTxBtnRef.current, 'SignTransactionButton not found');
       const inputAmountBase = commonToBase(
         inputAmount,
-        getDecimals({ asset: inputPosition.asset, chain: spendChain })
+        getDecimals({ asset: inputPosition.asset, chain: inputChain })
       ).toFixed();
       const outputAmountBase = commonToBase(
         selectedQuote.outputAmount.quantity,
-        getDecimals({ asset: outputPosition.asset, chain: spendChain })
+        getDecimals({ asset: outputPosition.asset, chain: inputChain })
       ).toFixed();
       const fallbackAddressAction = createTradeAddressAction({
         address,
         transaction: toMultichainTransaction(selectedQuote.transactionSwap),
         outgoing: [{ asset: inputPosition.asset, quantity: inputAmountBase }],
         incoming: [{ asset: outputPosition.asset, quantity: outputAmountBase }],
-        chain: spendChain,
+        chain: inputChain,
       });
 
       const txResponse = await sendTxBtnRef.current.sendTransaction({
         transaction: toMultichainTransaction(selectedQuote.transactionSwap),
-        chain: spendChain.toString(),
+        chain: inputChain.toString(),
         initiator: INTERNAL_ORIGIN,
         clientScope: 'Swap',
         feeValueCommon: selectedQuote.networkFee?.amount.quantity ?? null,
         addressAction: interpretationAction ?? fallbackAddressAction,
         quote: selectedQuote,
-        outputChain: inputChain ?? null,
+        outputChain: outputChain?.value ?? null,
       });
       return txResponse;
     },
@@ -825,7 +989,7 @@ function SwapFormComponent() {
         height="360px"
         containerStyle={{ display: 'flex', flexDirection: 'column' }}
         renderWhenOpen={() => {
-          invariant(spendChain, 'Chain must be defined');
+          invariant(inputChain, 'Chain must be defined');
           return (
             <>
               <DialogTitle
@@ -835,7 +999,7 @@ function SwapFormComponent() {
               />
               <Spacer height={24} />
               <SlippageSettings
-                chain={spendChain}
+                chain={inputChain}
                 configuration={toConfiguration(formState)}
                 onConfigurationChange={(value) => {
                   const partial = fromConfiguration(value);
@@ -858,7 +1022,7 @@ function SwapFormComponent() {
         renderWhenOpen={() => {
           invariant(currentTransaction, 'Tx must be defined to confirm');
           invariant(wallet, 'Current wallet not found');
-          invariant(spendChain, 'Chain must be defined');
+          invariant(inputChain, 'Chain must be defined');
 
           return (
             <ViewLoadingSuspense>
@@ -866,7 +1030,7 @@ function SwapFormComponent() {
                 formId={formId}
                 title={selectedQuote?.transactionApprove ? 'Approve' : 'Trade'}
                 wallet={wallet}
-                chain={spendChain}
+                chain={inputChain}
                 transaction={toMultichainTransaction(currentTransaction)}
                 configuration={toConfiguration(formState)}
                 customAllowanceValueBase={allowanceBase || undefined}
@@ -906,7 +1070,7 @@ function SwapFormComponent() {
         ref={allowanceDialogRef}
         height="min-content"
         renderWhenOpen={() => {
-          invariant(spendChain, 'Chain must be defined');
+          invariant(inputChain, 'Chain must be defined');
           invariant(inputAmount, 'inputAmount must be defined');
           invariant(
             inputPosition?.asset,
@@ -918,7 +1082,7 @@ function SwapFormComponent() {
           );
 
           const asset = inputPosition.asset;
-          const decimals = getDecimals({ asset, chain: spendChain });
+          const decimals = getDecimals({ asset, chain: inputChain });
           const spendAmountBase = commonToBase(inputAmount, decimals).toFixed();
           const value = new BigNumber(allowanceBase || spendAmountBase);
           const positionBalanceCommon = getPositionBalance(inputPosition);
@@ -942,7 +1106,7 @@ function SwapFormComponent() {
                 >
                   <AllowanceForm
                     asset={inputPosition.asset}
-                    chain={spendChain}
+                    chain={inputChain}
                     address={address}
                     balance={positionBalanceCommon}
                     requestedAllowanceQuantityBase={UNLIMITED_APPROVAL_AMOUNT}
@@ -987,16 +1151,18 @@ function SwapFormComponent() {
         }}
       >
         <VStack gap={16}>
-          <NetworkSelect
-            standard={getAddressType(address)}
-            showEcosystemHint={true}
-            value={formState.inputChain ?? ''}
-            onChange={(value) => {
-              handleChange('inputChain', value);
-            }}
-            dialogRootNode={rootNode}
-            filterPredicate={(network) => network.supports_trading}
-          />
+          {!isChainAbstractionEnabled ? (
+            <NetworkSelect
+              standard={getAddressType(address)}
+              showEcosystemHint={true}
+              value={inputChain?.value ?? ''}
+              onChange={(value) => {
+                handleChange('inputChain', value);
+              }}
+              dialogRootNode={rootNode}
+              filterPredicate={(network) => network.supports_trading}
+            />
+          ) : null}
           <VStack gap={4} style={{ position: 'relative' }}>
             <div style={{ position: 'relative' }}>
               <div className={styles.arcParent}>
@@ -1014,7 +1180,7 @@ function SwapFormComponent() {
                 onClick={() =>
                   setUserFormState((state) => ({
                     ...state,
-                    ...reverseTokens(formState),
+                    ...reverseTokens(formState, availablePositions),
                   }))
                 }
               />
@@ -1049,7 +1215,7 @@ function SwapFormComponent() {
               : undefined
           }
         >
-          {inputChainAddressMismatch ? (
+          {inputChainAddressMismatch && !isChainAbstractionEnabled ? (
             <UIText kind="small/regular" color="var(--notice-600)">
               {getAddressType(address) === 'evm'
                 ? 'Please switch to an Ethereum network'
@@ -1061,17 +1227,17 @@ function SwapFormComponent() {
             selectedQuote={selectedQuote}
             onQuoteIdChange={setUserQuoteId}
           />
-          {spendChain ? (
+          {inputChain ? (
             <SlippageLine
               formState={formState}
               receiveAsset={outputPosition?.asset ?? null}
-              chain={spendChain}
+              chain={inputChain}
               outputAmount={selectedQuote?.outputAmount.quantity ?? null}
             />
           ) : null}
           {isEthereumAddress(address) &&
           currentTransaction?.evm &&
-          spendChain ? (
+          inputChain ? (
             <React.Suspense
               fallback={
                 <div style={{ display: 'flex', justifyContent: 'end' }}>
@@ -1083,7 +1249,7 @@ function SwapFormComponent() {
                 keepPreviousData={true}
                 transaction={toIncomingTransaction(currentTransaction.evm)}
                 from={address}
-                chain={spendChain}
+                chain={inputChain}
                 paymasterEligible={Boolean(
                   currentTransaction.evm.customData?.paymasterParams
                 )}

--- a/src/ui/pages/SwapForm/fieldsets/ReceiveTokenField/MarketAssetSelect/MarketAssetSelect.tsx
+++ b/src/ui/pages/SwapForm/fieldsets/ReceiveTokenField/MarketAssetSelect/MarketAssetSelect.tsx
@@ -14,6 +14,7 @@ import { getAssetImplementationInChain } from 'src/modules/networks/asset';
 import { useCurrency } from 'src/modules/currency/useCurrency';
 import { useQuery } from '@tanstack/react-query';
 import type { BareAddressPosition } from 'src/shared/types/BareAddressPosition';
+import { useIsChainAbstractionEnabled } from 'src/shared/core/useIsChainAbstractionEnabled';
 import { getPopularTokens } from '../../../shared/getPopularTokens';
 
 export function MarketAssetSelect({
@@ -68,7 +69,10 @@ export function MarketAssetSelect({
     []
   );
 
-  const [searchAllNetworks, setSearchAllNetworks] = useState(false);
+  const isChainAbstractionEnabled = useIsChainAbstractionEnabled();
+  const [searchAllNetworks, setSearchAllNetworks] = useState(
+    isChainAbstractionEnabled || false
+  );
   const shouldQueryByChain = !searchAllNetworks && chain;
 
   const popularPositions = useMemo(() => {

--- a/src/ui/pages/SwapForm/shared/SwapFormState.ts
+++ b/src/ui/pages/SwapForm/shared/SwapFormState.ts
@@ -11,6 +11,8 @@ export type SwapFormState = {
   // from?: string;
   /** @description Recipient address for bridge transactions */
   to?: string;
+  /** @description Standardized token ID */
+  standardizedTokenId?: string;
   /** @description ID of the fungible token to swap from */
   inputFungibleId?: string;
   /** @description ID of the fungible token to swap to */

--- a/src/ui/pages/SwapForm/shared/usePosition.ts
+++ b/src/ui/pages/SwapForm/shared/usePosition.ts
@@ -5,6 +5,7 @@ import { isTruthy } from 'is-truthy-ts';
 import { useMemo } from 'react';
 import { useCurrency } from 'src/modules/currency/useCurrency';
 import type { Chain } from 'src/modules/networks/Chain';
+import { useIsChainAbstractionEnabled } from 'src/shared/core/useIsChainAbstractionEnabled';
 
 export function usePosition({
   assetId,
@@ -16,6 +17,7 @@ export function usePosition({
   chain: Chain | null;
 }) {
   const { currency } = useCurrency();
+  const isChainAbstractionEnabled = useIsChainAbstractionEnabled();
   const assetsPrices = useAssetsPrices(
     { asset_codes: [assetId].filter(isTruthy), currency },
     { client, enabled: Boolean(assetId) }
@@ -28,10 +30,10 @@ export function usePosition({
       positions?.find(
         (p) =>
           p.asset.id === assetId &&
-          p.chain === chain?.toString() &&
+          (p.chain === chain?.toString() || isChainAbstractionEnabled) &&
           p.type === 'asset'
       ) ?? null,
-    [assetId, positions, chain]
+    [assetId, positions, chain, isChainAbstractionEnabled]
   );
 
   return useMemo(() => {

--- a/src/ui/shared/requests/useSortedQuotes.ts
+++ b/src/ui/shared/requests/useSortedQuotes.ts
@@ -1,0 +1,30 @@
+import type { BridgeFormState } from 'src/ui/pages/BridgeForm/types';
+import type { SwapFormState } from 'src/ui/pages/SwapForm/shared/SwapFormState';
+import { useQuotes2 } from './useQuotes';
+
+type FormStateWithSort = SwapFormState | BridgeFormState;
+
+interface UseSortedQuotesParams {
+  address: string;
+  currency: string;
+  formState: FormStateWithSort;
+  enabled?: boolean;
+}
+
+/**
+ * Hook that returns quotes sorted by amount and time
+ * This allows components to switch between different sorting methods
+ * without making additional API calls
+ */
+export function useSortedQuotes(params: UseSortedQuotesParams) {
+  return {
+    quotesByAmount: useQuotes2({
+      ...params,
+      formState: { ...params.formState, sort: '1' },
+    }),
+    quotesByTime: useQuotes2({
+      ...params,
+      formState: { ...params.formState, sort: '2' },
+    }),
+  };
+}


### PR DESCRIPTION
This PR is part of the steps to add Orby chain abstraction on the Zerion Chrome Extension. The same steps and similar code can be used on other Chrome Extension wallets.

[✅] Step 0 PR(https://github.com/orb-labs/zerion-wallet-extension/pull/15): Setup feature flags
- create a remotely configurable feature flag called chain_abstraction_enabled. we will use this feature flag to gate access to the chain abstraction as we do progressive rollout of the feature.
Zerion uses firebase but you can feature flag system of your choice such as launch darkly

[✅] Step 1: Update Update OrbyConfig to include the other VM accounts and update signing of operations
- get all the addresses and accounts that you want to include together. For this Zerion example, we want to include all the accounts that are part of the same wallet group. That means account that are derived from the same mnemonic are grouped together regardless of the VM that they are part of. Specifically, Zerion supports both EVM and SVM, so we will have chain abstraction and unified balances on the SVM and EVM
- update the signing operations to fetch a signer based on the address that the operation is from
- use the feature flag from step 0 to turn on chain abstraction on Orby. When the feature flag is on, turn on chain abstraction on Orby for the user

Testing: At this point, we should have chain abstraction enabled for the accounts we set in the OrbyConfig
- import an account to Zerion using a mnemonic
- Connect to uniswap. You should see unified balances on the app across SVM and EVM. Also, you should be able to perform a transaction using the unified balances
- Connect jupiter (e.g. https://jup.ag/swap?sell=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&buy=So11111111111111111111111111111111111111112) you should also see your balances unified across EVM and SVM. Also, you should be able to perform a transaction using the unified balances

[✅] Step 2 PR(https://github.com/orb-labs/zerion-wallet-extension/pull/16): Introduce unified network and make it default
We want to separate the chain that the connected app is on from the chain / view that the user is on. To do that, we introduce the notion of `selectedChain` in the app preferences. This value can be updated/changed by the user and it is set to `NetworkSelectValue.Unified` by default. When an app ask for a chain switch, we update the `selectedChain` iff its current value is not `NetworkSelectValue.Unified`. 

Not, we do not seek to remove all the chains and allow user to be able to select `All Networks` and separate networks because we want to allow the option for users to see a particular view they want. Here is now the wallet looks with these changes:
<img width="369" height="470" alt="Screenshot 2025-07-22 at 11 57 52" src="https://github.com/user-attachments/assets/daae60ac-f96a-43da-96d3-f58d7fe3eb12" />

<img width="355" height="101" alt="Screenshot 2025-07-22 at 11 58 09" src="https://github.com/user-attachments/assets/74252f84-d7ab-4485-9264-ae9ff885d82f" />

<img width="367" height="97" alt="Screenshot 2025-07-22 at 11 58 27" src="https://github.com/user-attachments/assets/493cf6c7-e485-461c-9424-105416043c1d" />

[✅] Step 3 PR(https://github.com/orb-labs/zerion-wallet-extension/pull/17): Displaying a unified Portfolio view
When `selectedChain` is `NetworkSelectValue.Unified`, we want to display a unified view and total assets. Specifically, we want to keep the data data models that the wallet was already using. So, we:
1. fetch balances from wallet backend as we normally do
2. fetch balances from Orby
3. merge the 2 but prioritizing assets from the wallet backend. We only want orby balances for the total and breakdown but everything else stays the same.

This give us a view that looks like the following
<img width="361" height="783" alt="Screenshot 2025-07-22 at 14 01 58" src="https://github.com/user-attachments/assets/9951ba02-a235-4180-a276-ab27fe89a4ae" />

<img width="363" height="832" alt="Screenshot 2025-07-22 at 14 02 38" src="https://github.com/user-attachments/assets/9cbb997f-46aa-416d-990d-613f90d264fc" />

<img width="360" height="703" alt="Screenshot 2025-07-22 at 14 02 16" src="https://github.com/user-attachments/assets/81cd65c1-1c6f-4d20-94dc-bf54b2231e5e" />

[👉] Step 4: In-wallet chain abstracted sends
When `selectedChain` is `NetworkSelectValue.Unified`, we want to have chain abstracted sends and swaps.  

